### PR TITLE
[synse server] bump image version to 2.2.4-slim

### DIFF
--- a/synse/Chart.yaml
+++ b/synse/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse
-version: 0.0.9
+version: 0.0.10
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server
 icon: http://www.vapor.io/wp-content/uploads/2016/01/Vapor_Chamber_Logo.png

--- a/synse/values.yaml
+++ b/synse/values.yaml
@@ -8,10 +8,8 @@ image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
   # In general, all releases should use a *-slim image -- this is the image
-  # without the baked-in emulator. The two common -slim images are:
-  #  - edge-slim:   A build from the master branch  (for dev only; not guaranteed stable)
-  #  - latest-slim: A build from the latest release (should be stable)
-  tag: latest
+  # without the baked-in emulator.
+  tag: v2.2.4-slim
   pullPolicy: Always
 
 ## Service configurations for Synse Server.


### PR DESCRIPTION
In doing this update, one thing I was wondering was whether the chart version should in any way match, or otherwise give info about, the version of synse-server being used. 

e.g., if we are using `vaporio/synse-server:2.2.4`, should the chart version be `2.2.4-XXX` where the `-XXX` would be used to define versions for updates not related to the image version (e.g. changing environment variables, updating deployment resources, ...)

I'm not at all married to the idea, but I could see it becoming confusing to track which chart version corresponds with which image version.