### PR TITLE
[synse server] create cluster permissions for plugin discovery

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse-server
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.2.4
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/clusterrole.yaml
+++ b/synse-server/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fullname" . }}
+rules:
+- apiGroups: [""]                 # Empty string means Core API group
+  resources: ["endpoints"]        # Synse Server plugin discovery operates on Endpoint resources
+  verbs: ["get", "watch", "list"]

--- a/synse-server/templates/clusterrole.yaml
+++ b/synse-server/templates/clusterrole.yaml
@@ -1,3 +1,8 @@
+# If Synse Server is configured to run with plugin discovery via the
+# Kubernetes API, this template will be rendered. If the Kubernetes
+# discovery config is not set, Synse Server will not use the Kubernetes
+# API and will not need to be granted additional cluster permissions.
+{{- if .Values.config.plugin.discover.kubernetes }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6,3 +11,4 @@ rules:
 - apiGroups: [""]                 # Empty string means Core API group
   resources: ["endpoints"]        # Synse Server plugin discovery operates on Endpoint resources
   verbs: ["get", "watch", "list"]
+{{- end }}

--- a/synse-server/templates/clusterrolebinding.yaml
+++ b/synse-server/templates/clusterrolebinding.yaml
@@ -1,3 +1,8 @@
+# If Synse Server is configured to run with plugin discovery via the
+# Kubernetes API, this template will be rendered. If the Kubernetes
+# discovery config is not set, Synse Server will not use the Kubernetes
+# API and will not need to be granted additional cluster permissions.
+{{- if .Values.config.plugin.discover.kubernetes }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +19,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/synse-server/templates/clusterrolebinding.yaml
+++ b/synse-server/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+{{ include "labels" . | indent 4 }}
+  annotations:
+{{ include "annotations" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
 {{ include "annotations" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: 3
+      serviceAccountName: {{ template "fullname" . }}
       volumes:
       - name: config
         configMap:

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -20,7 +20,13 @@ spec:
 {{ include "annotations" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: 3
+      {{- if .Values.config.plugin.discover.kubernetes }}
+      # If Synse Server is configured to run with plugin discovery via the
+      # Kubernetes API, use the ServiceAccount that was created for it. The
+      # ServiceAccount will give Synse Server the proper cluster permissions
+      # to use the required Kubernetes API components.
       serviceAccountName: {{ template "fullname" . }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/synse-server/templates/serviceaccount.yaml
+++ b/synse-server/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+{{ include "labels" . | indent 4 }}

--- a/synse-server/templates/serviceaccount.yaml
+++ b/synse-server/templates/serviceaccount.yaml
@@ -1,6 +1,12 @@
+# If Synse Server is configured to run with plugin discovery via the
+# Kubernetes API, this template will be rendered. If the Kubernetes
+# discovery config is not set, Synse Server will not use the Kubernetes
+# API and will not need to be granted additional cluster permissions.
+{{- if .Values.config.plugin.discover.kubernetes }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}
   labels:
 {{ include "labels" . | indent 4 }}
+{{- end }}


### PR DESCRIPTION
fixes #5 

Tested this on Austin running only Synse Server and some plugins. Without these changes, I saw the permissions failure. With these changes, plugin discovery completed successfully and there were no errors in the logs. 