### PR TITLE
[modbus] freeze image version at 1.1.0, bump chart version

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,7 +1,8 @@
 ---
 
 name: modbus
-version: 0.1.0
+version: 0.2.0
+appVersion: 1.1.0
 description: Synse Modbus Over IP Plugin.
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin
 icon: https://charts.vapor.io/.images/synse-modbus.jpg

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/modbus-ip-plugin
-  tag: latest # Or should this be edge - I don't know.
+  tag: "1.1.0"
   pullPolicy: Always
 
 ## Service configurations for the modbus plugin.


### PR DESCRIPTION
The modbus-ip plugin was recently bumped to version 1.1.0 -- this PR updates the helm chart to use that version.
