### PR TITLE
By default deploy master / mainline / git head / latest.

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: modbus
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.1.0
 description: Synse Modbus Over IP Plugin.
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/modbus-ip-plugin
-  tag: "1.1.0"
+  tag: "edge" # Current master / latest / mainline is tagged edge.
   pullPolicy: Always
 
 ## Service configurations for the modbus plugin.


### PR DESCRIPTION
This updates to deploy the modbus image built off of git head rather than something we built (currently) 18 days ago.