### PR TITLE
[synse-server] Allow for ingress hostname to be configured

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse-server
-version: 0.1.1
+version: 0.2.0
 appVersion: 2.2.4
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/configmap.yaml
+++ b/synse-server/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "name" . }}-config
+  name: {{ template "fullname" . }}-config
   labels:
 {{ include "labels" . | indent 4 }}
   annotations:

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "name" . }}-config
+          name: {{ template "fullname" . }}-config
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/synse-server/templates/ingress.yaml
+++ b/synse-server/templates/ingress.yaml
@@ -10,7 +10,18 @@ metadata:
   annotations:
 {{ include "annotations" . | indent 4 }}
 spec:
+  {{- if .Values.ingress.hostname }}
+  rules:
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: {{ .Values.service.port }}
+  {{- else }}
   backend:
-    serviceName: {{ template "name" . }}
+    serviceName: {{ template "fullname" . }}
     servicePort: {{ .Values.service.port }}
+  {{- end }}
 {{- end }}

--- a/synse-server/templates/service.yaml
+++ b/synse-server/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "fullname" . }}
   labels:
 {{ include "labels" . | indent 4 }}
   annotations:

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -23,10 +23,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
+  hostname: ""
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 ## Configure resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
This keeps current functionality. However, if you `Values.ingress.hostname` is set it will switch to vhost routing