### PR TITLE
[Synse Server] - Add TLS to ingress and defaults

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse-server
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.2.6
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/ingress.yaml
+++ b/synse-server/templates/ingress.yaml
@@ -9,7 +9,16 @@ metadata:
 {{ include "labels" . | indent 4 }}
   annotations:
 {{ include "annotations" . | indent 4 }}
+{{ if .Values.ingress.annotations -}}
+{{ toYaml .Values.ingress.annotations | indent 4 -}}
+{{- end }}
 spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    - secretName: {{ template "fullname" . }}-tls
+      hosts:
+      {{ toYaml .Values.ingress.tls -}}
+  {{- end -}}
   {{- if .Values.ingress.hostname }}
   rules:
   - host: {{ .Values.ingress.hostname }}

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -20,9 +20,9 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   hostname: ""
   tls: []
 


### PR DESCRIPTION
- Helm chart values are additive, so if you specify a label/annotation
it'll hand it down into the values.yaml, making it impossible to delete
a default that is a list/object type.
- Move the onus of configuration to the values.yaml provided by the
operator
- Add TLS annotations
- Fix a bug where values.yaml ingress annotations were not being handed
down
- Various chomps on various things because formatting yaml from a
mustache template is legit hard.