### PR TITLE
[synse-server] bump chart to 0.3.1, allow overriding built-in emulato…

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse-server
-version: 0.2.3
+version: 0.3.1
 appVersion: 2.2.6
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/NOTES.txt
+++ b/synse-server/templates/NOTES.txt
@@ -1,3 +1,31 @@
+{{- if .Values.devices }}
+---------------------------------------
+Synse Server has been configured with device configurations that override
+the default built-in emulator configurations.
+
+Using '-slim' image: {{ if not (contains "-slim" .Values.image.tag) }}OK{{ else }}ERROR
+
+  The '-slim' variant of the Synse Server image is being used but does
+  not have the built-in emulator. Custom emulator device configurations
+  will NOT be rendered unless a non-slim image is used. Simply removing
+  the '-slim' suffix from the tag will give a version with built-in
+  emulator.
+
+{{- end }}
+
+Emulator enabled:    {{ if has "enable-emulator" .Values.args }}OK{{ else }}ERROR
+
+  The emulator has device configurations, but is not configured to run.
+  To run the built-in emulator, add the following in your values.yaml:
+
+    args:
+      - enable-emulator
+
+{{- end }}
+
+---------------------------------------
+{{- end }}
+
 Current Configuration:
 
 {{ toYaml .Values | indent 4 }}

--- a/synse-server/templates/configmap.yaml
+++ b/synse-server/templates/configmap.yaml
@@ -10,3 +10,16 @@ data:
   {{- if .Values.config }}
   config.yml: {{ toYaml .Values.config | quote }}
   {{- end }}
+{{- if and (not (contains "-slim" .Values.image.tag)) (.Values.devices) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-emulator-devices
+  labels:
+{{ include "labels" . | indent 4 }}
+  annotations:
+{{ include "annotations" . | indent 4 }}
+data:
+  config.yml: {{ toYaml .Values.devices | quote }}
+{{- end }}

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -31,6 +31,11 @@ spec:
       - name: config
         configMap:
           name: {{ template "fullname" . }}-config
+      {{- if and (not (contains "-slim" .Values.image.tag)) (.Values.devices) }}
+      - name: emulator-devices
+        configMap:
+          name: {{ template "fullname" . }}-emulator-devices
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -54,9 +59,18 @@ spec:
           httpGet:
             path: /synse/test
             port: http
+        {{- if and (not (contains "-slim" .Values.image.tag)) (.Values.devices) }}
+        env:
+        - name: PLUGIN_DEVICE_CONFIG
+          value: /synse/emulator/tmp
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /synse/config
+        {{- if and (not (contains "-slim" .Values.image.tag)) (.Values.devices) }}
+        - name: emulator-devices
+          mountPath: /synse/emulator/tmp
+        {{- end }}
         {{ if .Values.resources -}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -36,6 +36,9 @@ resources:
 ## Component
 component: server
 
+## Arguments to pass to Synse Server. By default, no arguments are passed.
+args: []
+
 ## Synse Server configuration. This configuration is placed into a ConfigMap where
 ## it is then mounted into the container. The config options here can be overridden
 ## with environment variables, if desired. For more information on configuring Synse
@@ -59,3 +62,9 @@ config:
             # all plugins must have a service with the "component=plugin"
             # label set.
             component: plugin
+
+## Devices can be used to define an override device configuration for the built-in emulator.
+## This will only matter if you are using a non-slim variant of the Synse Server image. Be
+## sure to also run the emulator by setting:
+## args: ["enable-emulator"]
+#devices: {}


### PR DESCRIPTION
…r device configurations


This change allows someone to use custom device configurations for the built-in emulator. The changes here are similar to the emulator changes in #13 