### PR TITLE
[synse-server] Adds env passthrough

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: synse-server
-version: 0.2.3
+version: 0.3.0
 appVersion: 2.2.6
 description: An HTTP API for the monitoring and control of physical and virtual devices.
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
+        # Allow tuning through env in values.yaml
+        {{- if .Values.env }}
+        env:
+{{ toYaml .Values.env | indent 10 -}}
+        {{- end -}}
         # Basic readiness/liveness probes. These could be expanded upon in the future.
         livenessProbe:
           initialDelaySeconds: 30

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -26,6 +26,9 @@ ingress:
   hostname: ""
   tls: []
 
+## Allow pass-through env variable configuration of synse server
+#env: {}
+
 ## Configure resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources:


### PR DESCRIPTION
- Synse-server supports configuration via env but the chart template
exposes no means to configure the env of a deployed synse-server. This
chart modification grants a direct YAML env block for passthrough in the
template.