### PR TITLE
[emulator] - Embed the configmap hash to trigger pod rollout

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: emulator
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.3.1
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin

--- a/emulator/templates/deployment.yaml
+++ b/emulator/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
   annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "annotations" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
- Adding the configmap hash to deployment, so when we apply a config
change the emulator will rollout the change autonomously vs requiring a
bounce of the pods manually.