### PR TITLE
[emulator] - Move configmap hash to podspec template

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 
 name: emulator
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.3.1
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin

--- a/emulator/templates/deployment.yaml
+++ b/emulator/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "annotations" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -18,6 +17,7 @@ spec:
       labels:
 {{ include "labels" . | indent 8 }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "annotations" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: 3


### PR DESCRIPTION
- I errantly placed this in the deployment metadata, not the podspec
metadata during the initial pr. This fixes the bug introduced in: #20