### PR TITLE
[synse-emulator-plugin] - Support globally unique device GUID

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 
 name: emulator
-version: 0.2.4
-appVersion: 2.3.1
+version: 0.2.5
+appVersion: 2.4.3
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "2.4.2"
+  tag: "2.4.3"
   pullPolicy: Always
 
 ## Service configurations for the emulator plugin.


### PR DESCRIPTION
- Synse Emulator Plugin as of 2.4.3 uses device.GUID instead of
device.ID to identify devices, which serializes
location,rack,device-id for the devices.