### PR TITLE
[synse-emulator-plugin] - Release 2.4.4

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 
 name: emulator
-version: 0.2.5
-appVersion: 2.4.3
+version: 0.2.6
+appVersion: 2.4.4
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "2.4.3"
+  tag: "2.4.4"
   pullPolicy: Always
 
 ## Service configurations for the emulator plugin.


### PR DESCRIPTION
- Technically should be 2.5.0 but i botched a release increment. I
digress: contains the deprecation of state in favor of status for lock
devices.

Hand in hand with: https://github.com/vapor-ware/management-api/pull/68
and
https://github.com/vapor-ware/synse-emulator-plugin/pull/47