### PR TITLE
[synse-emulator] - Adds Voltage and Kilowatthour devices

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 
 name: emulator
-version: 0.2.9
-appVersion: 2.4.8
+version: 0.2.10
+appVersion: 2.5.0
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "2.4.8"
+  tag: "2.5.0"
   pullPolicy: Always
 
 ## Service configurations for the emulator plugin.


### PR DESCRIPTION
- Adds support for declaring/consuming Voltage devices
- Adds support for declaring/consuming KilowattHour devices
- Bumps chart rev 0.2.10
- bumps default image to 2.5.0