### PR TITLE
[synse-emulator-plugin] emulator 2.5.2

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 
 name: emulator
-version: 0.2.10
-appVersion: 2.5.0
+version: 0.2.12
+appVersion: 2.5.2
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "2.5.0"
+  tag: "2.5.2"
   pullPolicy: Always
 
 ## Service configurations for the emulator plugin.


### PR DESCRIPTION
- Release a patch for current device labels
- bumps to 2.5.2 of the emulator
- bumps chart to 0.2.12