### PR TITLE
[synse-emulator] - Default to 2.5.3

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 
 name: emulator
-version: 0.2.12
-appVersion: 2.5.2
+version: 0.2.13
+appVersion: 2.5.3
 description: Emulator plugin for Synse Server.
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg
@@ -11,3 +11,5 @@ maintainers:
   email: erick@vapor.io
 - name: Marco Ceppi
   email: marco@vapor.io
+- name: Charles Butler
+  email: chuck@vapor.io

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "2.5.2"
+  tag: "2.5.3"
   pullPolicy: Always
 
 ## Service configurations for the emulator plugin.


### PR DESCRIPTION
- 2.5.2 was a broken image. 2.5.3 corrects the "current" device readings
  which were incorrectly searching for "amperage" output types.