### PR TITLE
[synse-server] updates for v3.0.0-alpha.2

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.1
-appVersion: 3.0.0-alpha.1
+version: 3.0.0-alpha.2
+appVersion: 3.0.0-alpha.2
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/templates/clusterrole.yaml
+++ b/synse-server/templates/clusterrole.yaml
@@ -1,11 +1,9 @@
 {{- /*
-  If Synse Server is configured to run with plugin discovery via the
-  Kubernetes API, this template will be rendered. If the Kubernetes
-  discovery config is not set, Synse Server will not use the Kubernetes
-  API and will not need to be granted additional cluster permissions.
+  Synse Server only needs a ClusterRole definition if plugin discovery
+  via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.config.plugin.discover.kubernetes }}
+{{- if .Values.clusterRoles.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/synse-server/templates/clusterrolebinding.yaml
+++ b/synse-server/templates/clusterrolebinding.yaml
@@ -1,11 +1,9 @@
 {{- /*
-  If Synse Server is configured to run with plugin discovery via the
-  Kubernetes API, this template will be rendered. If the Kubernetes
-  discovery config is not set, Synse Server will not use the Kubernetes
-  API and will not need to be granted additional cluster permissions.
+  Synse Server only needs a ClusterRole definition if plugin discovery
+  via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.config.plugin.discover.kubernetes }}
+{{- if .Values.clusterRoles.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "annotations" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 3
-      {{- if .Values.config.plugin.discover.kubernetes }}
+      {{- if .Values.clusterRoles.enabled }}
       # Synse Server is configured to run with plugin discovery using the Kubernetes
       # API. Use the ServiceAccount to give it the proper cluster permissions.
       serviceAccountName: {{ template "fullname" . }}
@@ -73,7 +73,7 @@ spec:
         {{- if .Values.config }}
         volumeMounts:
         - name: config
-          mountPath: /synse/config
+          mountPath: /etc/synse/server
         {{- end }}
         {{ if .Values.resources -}}
         resources:

--- a/synse-server/templates/serviceaccount.yaml
+++ b/synse-server/templates/serviceaccount.yaml
@@ -1,11 +1,9 @@
 {{- /*
-  If Synse Server is configured to run with plugin discovery via the
-  Kubernetes API, this template will be rendered. If the Kubernetes
-  discovery config is not set, Synse Server will not use the Kubernetes
-  API and will not need to be granted additional cluster permissions.
+  Synse Server only needs a ClusterRole definition if plugin discovery
+  via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.config.plugin.discover.kubernetes }}
+{{- if .Values.clusterRoles.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -5,14 +5,23 @@
 ## Deployment replication configuration.
 replicaCount: 1
 
-# Override the serialized names which are typically $release-name-$app
+## Override the serialized names which are typically $release-name-$app
 fullNameOverride: ""
+
+## Enable/disable the creation of a ClusterRole, ClusterRoleBinding, and
+## ServiceAccount. This is false by default, as Synse does not need additional
+## permissions with its default settings.
+##
+## If Synse Server is configured for plugin discovery via the Kubernetes API,
+## this must be enabled.
+clusterRoles:
+  enabled: false
 
 ## Image configuration options.
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
-  tag: "v3.0.0-alpha.1"
+  tag: "v3.0.0-alpha.2"
   pullPolicy: Always
 
 ## Service configuration options.
@@ -62,16 +71,4 @@ readinessProbe:
 ## it is then mounted into the container. The config options here can be overridden
 ## with environment variables, if desired. For more information on configuring Synse
 ## Server, see: https://synse.readthedocs.io/en/latest/server/user/configuration/
-##
-## The default behavior for the Synse chart, as defined below, is to automatically
-## look for plugins based on Kubernetes endpoint labels, specifically the label:
-## component: plugin
-config:
-  logging: debug
-  pretty_json: true
-  plugin:
-    discover:
-      kubernetes:
-        endpoints:
-          labels:
-            synse-component: plugin
+# config: {}


### PR DESCRIPTION
* updates to synse-server v3.0.0-alpha.2 image, which includes minor cleanup and logging changes
* updates the mount path of the configmap to synse-server's v3 default config location
* removes default config specified in values.yaml, since it appears that this was being merged with override config, not replaced by override config.
* adds an explicit config option for enabling cluster roles (+ cluster role binding, + service account) creation. without this, chart linting will fail because we cannot resolve the config discovery value which was present by default before. this means that it is up to the chart user to explicitly enable cluster role creation if synse-server is configured for plugin discovery via the Kubernetes API.