### PR TITLE
[synse-server] bump to 3.0.0-alpha.8 and general chart updates

### DIFF
--- a/emulator/templates/NOTES.txt
+++ b/emulator/templates/NOTES.txt
@@ -1,3 +1,3 @@
-Current Configuration:
-
-{{ toYaml .Values | indent 4 }}
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}

--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.7
-appVersion: 3.0.0-alpha.7
+version: 3.0.0-alpha.8
+appVersion: 3.0.0-alpha.8
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -41,4 +41,40 @@ The following table lists the configurable parameters of the Synse Server chart 
 
 | Parameter | Description | Default |
 | :-------- | :---------- | :------ |
-| `` |  |  |
+| `config` | The [Synse Server configuration YAML](https://synse.readthedocs.io/en/v3/server/user/configuration/). This is mounted into `/etc/synse/server/config.yaml` if specified. | `{}` |
+| `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
+| `fullnameOverride` | Fully override the fullname template. | `""` |
+| `rbac.create` | Create RBAC resources and a ServiceAccount for the Synse Server deployment to use. This must be done if Synse Server is configured to use plugin discovery via Kubernetes endpoints. | `false` |
+| `image.registry` | The image registry to use. | `""` |
+| `image.repository` | The name of the image to use. | `vaporio/synse-server` |
+| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.8` |
+| `image.pullPolicy` | The image pull policy. | `Always` |
+| `deployment.labels` | Additional labels for the Deployment. | `{}` |
+| `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
+| `deployment.replicas` | The number of replicas to deploy with. | `1` |
+| `pod.labels` | Additional labels for the Pod. | `{}` |
+| `pod.annotations` | Additional annotations for the Pod. | `{}` |
+| `service.labels` | Additional labels for the Service. | `{}` |
+| `service.annotations` | Additional annotations for the Service. | `{}` |
+| `service.type` | The type of the Service. | `ClusterIP` |
+| `service.port` | The Service port to expose. | `5000` |
+| `ingress.enabled` | Enable/disable creation of an Ingress resource. | `false` |
+| `ingress.labels` | Additional labels for the Ingress. | `{}` |
+| `ingress.annotations` | Additional annotations for the Ingress | `{}` |
+| `ingress.hostname` | The Ingress hostname. | `""` |
+| `ingress.tls` | Ingress TLS configuration (YAML). | `[]` |
+| `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
+| `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `30` |
+| `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `5` |
+| `livenessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `readinessProbe.enabled` | Enable/disable the readiness probe check. | `true` |
+| `readinessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `5` |
+| `readinessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `readinessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `args` | Additional arguments to pass to the container. | `[]` |
+| `env` | Additional environment variables to set for the container. This may be used for configuring Synse Server as well. | `{}` |
+| `resources.requests` | Pod requests resources. | `{}` |
+| `resources.limits` | Pod limits resources. | `{}` |
+| `nodeSelector` | Node labels for Pod assignment. | `{}` |
+| `tolerations` | Node taints to tolerate. | `[]` |
+| `affinity` | Pod affinity. | `{}` |

--- a/synse-server/templates/_helpers.tpl
+++ b/synse-server/templates/_helpers.tpl
@@ -1,5 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-
 {{/*
   Expand the name of the chart.
 */}}
@@ -14,29 +13,20 @@
 */}}
 {{- define "fullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- printf .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-  Output the common labels used.
-*/}}
-{{- define "labels" -}}
-{{ template "selector" . }}
-heritage: {{ .Release.Service | quote }}
-{{- end -}}
-
-{{- define "annotations" -}}
-chart: "{{ .Chart.Name }}"
 {{- end -}}
 
 {{/*
-  Selector to pick a specific release/app.
+  Create chart name and version as used by the chart label.
 */}}
-{{- define "selector" -}}
-app: {{ include "name" . | quote }}
-release: {{ .Release.Name | quote }}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/synse-server/templates/clusterrole.yaml
+++ b/synse-server/templates/clusterrole.yaml
@@ -3,13 +3,25 @@
   via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.clusterRoles.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
-- apiGroups: [""]                 # Empty string means Core API group
-  resources: ["endpoints"]        # Synse Server plugin discovery operates on Endpoint resources
-  verbs: ["get", "watch", "list"]
+# Core API Group
+- apiGroups: [""]
+  # Synse Server plugin discovery currently operates on Endpoint resources.
+  # If support for more resources is added, this should be updated accordingly.
+  resources:
+  - "endpoints"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
 {{- end }}

--- a/synse-server/templates/clusterrolebinding.yaml
+++ b/synse-server/templates/clusterrolebinding.yaml
@@ -3,15 +3,16 @@
   via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.clusterRoles.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
-  annotations:
-    {{- include "annotations" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/synse-server/templates/configmap.yaml
+++ b/synse-server/templates/configmap.yaml
@@ -4,9 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-config
   labels:
-    {{- include "labels" . | nindent 4 }}
-  annotations:
-    {{- include "annotations" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -3,25 +3,41 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+  {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      {{- include "selector" . | nindent 6 }}
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       name: {{ template "fullname" . }}
       labels:
-        {{- include "labels" . | nindent 8 }}
+        app: {{ template "name" . }}
+        chart: {{ template "chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- include "annotations" . | nindent 8 }}
+        {{- if .Values.pod.annotations }}
+        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 3
-      {{- if .Values.clusterRoles.enabled }}
+      {{- if .Values.rbac.create }}
       # Synse Server is configured to run with plugin discovery using the Kubernetes
       # API. Use the ServiceAccount to give it the proper cluster permissions.
       serviceAccountName: {{ template "fullname" . }}
@@ -39,14 +55,12 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}
-          hostPort: {{ .Values.service.port }}
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
-        {{- /* Allow tuning through env in values.yaml */}}
         {{- if .Values.env }}
         env:
-          {{- toYaml .Values.env | nindent 10 }}
+          {{- toYaml .Values.env | trim | nindent 10 }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         {{- with .Values.livenessProbe }}
@@ -77,5 +91,17 @@ spec:
         {{- end }}
         {{ if .Values.resources -}}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- toYaml .Values.resources | trim | nindent 10 }}
         {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | trim | nindent 8 }}
+      {{- end }}

--- a/synse-server/templates/ingress.yaml
+++ b/synse-server/templates/ingress.yaml
@@ -1,15 +1,20 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
-  annotations:
-    {{- include "annotations" . | nindent 4 }}
-    {{- if .Values.ingress.annotations }}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.ingress.labels }}
+    {{- toYaml .Values.ingress.labels | trim | nindent 4 }}
     {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | trim | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:

--- a/synse-server/templates/service.yaml
+++ b/synse-server/templates/service.yaml
@@ -3,14 +3,22 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: http
     name: http
   selector:
-    {{- include "selector" . | nindent 4 }}
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/synse-server/templates/serviceaccount.yaml
+++ b/synse-server/templates/serviceaccount.yaml
@@ -3,11 +3,15 @@
   via the Kubernetes API is configured.
 */ -}}
 
-{{- if .Values.clusterRoles.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- end }}

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-## Deployment replication configuration.
-replicaCount: 1
+## Partially override the fullname template (will maintain the release name).
+nameOverride: ""
 
-## Override the serialized names which are typically $release-name-$app
-fullNameOverride: ""
+## Fully override the fullname template.
+fullnameOverride: ""
 
 ## Enable/disable the creation of a ClusterRole, ClusterRoleBinding, and
 ## ServiceAccount. This is false by default, as Synse does not need additional
@@ -14,19 +14,32 @@ fullNameOverride: ""
 ##
 ## If Synse Server is configured for plugin discovery via the Kubernetes API,
 ## this must be enabled.
-clusterRoles:
-  enabled: false
+rbac:
+  create: false
 
 ## Image configuration options.
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
-  tag: "v3.0.0-alpha.7"
+  tag: "v3.0.0-alpha.8"
   pullPolicy: Always
+
+## Deployment configuration options.
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Pod configuration options.
+pod:
+  annotations: {}
+  labels: {}
 
 ## Service configuration options.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 service:
+  annotations: {}
+  labels: {}
   type: ClusterIP
   port: 5000
 
@@ -35,23 +48,11 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  labels: {}
   hostname: ""
   tls: []
-
-## Allow pass-through environment variable configuration.
-#env: {}
-
-## Configure resource requests and limits.
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources:
-  requests:
-   cpu: 33m
-   memory: 150Mi
-
-## Specify arguments to pass to the container. By default, no arguments are passed.
-args: []
 
 ## Readiness and liveness probe configuration options
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -66,9 +67,32 @@ readinessProbe:
   timeoutSeconds: 2
   periodSeconds: 5
 
+## Specify arguments to pass to the container. By default, no arguments are passed.
+args: []
+
+## Allow pass-through environment variable configuration.
+env: {}
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests: {}
+  limits: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
 
 ## Synse Server configuration. This configuration is placed into a ConfigMap where
 ## it is then mounted into the container. The config options here can be overridden
 ## with environment variables, if desired. For more information on configuring Synse
 ## Server, see: https://synse.readthedocs.io/en/latest/server/user/configuration/
-# config: {}
+config: {}


### PR DESCRIPTION
This PR:
- bumps the chart and image version to [3.0.0-alpha.8](https://github.com/vapor-ware/synse-server/releases/tag/v3.0.0-alpha.8)
- documents the configurable values in the README
- general chart updates and cleanup to make things more flexible (e.g. add affinity, tolerations, nodeSelector, etc) and more explicit (e.g. not using template for labels/annotations/selectors, etc).
- reorganizes some of the options in values.yaml
  - changes `clusterRoles` option to `rbac` since it seems more appropriate given the scope of resources it creates.
- updates NOTES.txt to not just wholesale dump the entire values config which everyone ignores, but instead just print out the chart/app version. may or may not be useful, but its not a wall of config that gets ignored anyways.

of note, this also removes the `hostPort` set in the deployment config. I recall that it was causing some issues w/ blackbox before. not sure if it makes sense to remove it here or not, so i'm open to recommendation on that.