### PR TITLE
[emulator] bump app to 3.0.0-alpha.8, general chart updates

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: emulator
-version: 3.0.0-alpha.5
-appVersion: 3.0.0-alpha.5
+version: 3.0.0-alpha.6
+appVersion: 3.0.0-alpha.8
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -41,4 +41,34 @@ The following table lists the configurable parameters of the Synse Emulator Plug
 
 | Parameter | Description | Default |
 | :-------- | :---------- | :------ |
-| `` |  |  |
+| `config` | The Emulator Plugin configuration. | `{}` |
+| `devices` | Custom emulator devices configuration. If this is not set, the default built-in device configs are used.| `{}` |
+| `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
+| `fullnameOverride` | Fully override the fullname template. | `""` |
+| `image.registry` | The image registry to use. | `""` |
+| `image.repository` | The name of the image to use. | `vaporio/emulator-plugin` |
+| `image.tag` | The tag of the image to use. | `3.0.0-alpha.8` |
+| `image.pullPolicy` | The image pull policy. | `Always` |
+| `deployment.labels` | Additional labels for the Deployment. | `{}` |
+| `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
+| `deployment.replicas` | The number of replicas to deploy with. | `1` |
+| `pod.labels` | Additional labels for the Pod. | `{}` |
+| `pod.annotations` | Additional annotations for the Pod. | `{}` |
+| `service.labels` | Additional labels for the Service. | `{}` |
+| `service.annotations` | Additional annotations for the Service. | `{}` |
+| `service.port` | The Service port to expose. | `5001` |
+| `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
+| `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `30` |
+| `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `5` |
+| `livenessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `readinessProbe.enabled` | Enable/disable the readiness probe check. | `true` |
+| `readinessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `5` |
+| `readinessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `readinessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `args` | Additional arguments to pass to the container. | `[]` |
+| `env` | Additional environment variables to set for the container. This may be used for configuring the plugin as well. | `{}` |
+| `resources.requests` | Pod requests resources. | `{}` |
+| `resources.limits` | Pod limits resources. | `{}` |
+| `nodeSelector` | Node labels for Pod assignment. | `{}` |
+| `tolerations` | Node taints to tolerate. | `[]` |
+| `affinity` | Pod affinity. | `{}` |

--- a/emulator/templates/NOTES.txt
+++ b/emulator/templates/NOTES.txt
@@ -1,3 +1,3 @@
-Current Configuration:
-
-{{ toYaml .Values | indent 4 }}
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}

--- a/emulator/templates/_helpers.tpl
+++ b/emulator/templates/_helpers.tpl
@@ -1,5 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-
 {{/*
   Expand the name of the chart.
 */}}
@@ -13,27 +12,21 @@
   If release name contains chart name it will be used as a full name.
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-
-{{/*
-  Output the common labels used.
-*/}}
-{{- define "labels" -}}
-{{ template "selector" . }}
-heritage: {{ .Release.Service | quote }}
 {{- end -}}
-
-{{- define "annotations" -}}
-chart: "{{ .Chart.Name }}"
 {{- end -}}
 
 {{/*
-  Selector to pick a specific release/app.
+  Create chart name and version as used by the chart label.
 */}}
-{{- define "selector" -}}
-app: {{ include "name" . | quote }}
-release: {{ .Release.Name | quote }}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/emulator/templates/configmap.yaml
+++ b/emulator/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if (or .Values.config .Values.devices) }}
-{{ if .Values.config }}
+{{- if .Values.config }}
 # Plugin configuration
 apiVersion: v1
 kind: ConfigMap
@@ -7,14 +7,16 @@ metadata:
   name: {{ template "fullname" . }}-config
   labels:
     synse-component: plugin
-    {{- include "labels" . | nindent 4 }}
-  annotations:
-    {{- include "annotations" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}
-{{ if .Values.devices }}
+{{- if .Values.devices }}
 ---
+
 # Device configuration
 apiVersion: v1
 kind: ConfigMap
@@ -22,9 +24,10 @@ metadata:
   name: {{ template "fullname" . }}-devices
   labels:
     synse-component: plugin
-    {{- include "labels" . | nindent 4 }}
-  annotations:
-    {{- include "annotations" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   config.yml: {{ toYaml .Values.devices | quote }}
 {{- end }}

--- a/emulator/templates/deployment.yaml
+++ b/emulator/templates/deployment.yaml
@@ -4,24 +4,40 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     synse-component: plugin
-    {{- include "labels" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+  {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       synse-component: plugin
-      {{- include "selector" . | nindent 6 }}
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       name: {{ template "fullname" . }}
       labels:
         synse-component: plugin
-        {{- include "labels" . | nindent 8 }}
+        app: {{ template "name" . }}
+        chart: {{ template "chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- include "annotations" . | nindent 8 }}
+        {{- if .Values.pod.annotations }}
+        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 3
       {{- if (or .Values.config .Values.devices) }}
@@ -32,7 +48,7 @@ spec:
             name: {{ template "fullname" . }}-config
         {{- end }}
         {{- if .Values.devices }}
-        - name: device-config
+        - name: devices
           configMap:
             name: {{ template "fullname" . }}-devices
         {{- end }}
@@ -47,29 +63,20 @@ spec:
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
-        {{- if (or .Values.config .Values.devices) }}
+        {{- if .Values.env }}
         env:
-        # We need to manually specify a non-default path here. If we
-        # mount the config to the default path, the built-in emulator
-        # configs will not get picked up.
-        {{- if .Values.config }}
-        - name: PLUGIN_CONFIG
-          value: /tmp/synse/plugin
-        {{- end }}
-        {{- if .Values.devices}}
-        - name: PLUGIN_DEVICE_CONFIG
-          value: /tmp/synse/devices
-        {{- end }}
+          {{- toYaml .Values.env | trim | nindent 10 }}
         {{- end }}
         {{- if (or .Values.config .Values.devices) }}
         volumeMounts:
         {{- if .Values.config }}
         - name: config
-          mountPath: /tmp/synse/plugin
+          mountPath: /etc/synse/plugin/config/config.yml
+          subPath: config.yml
         {{- end }}
         {{- if .Values.devices }}
-        - name: device-config
-          mountPath: /tmp/synse/devices
+        - name: devices
+          mountPath: /etc/synse/plugin/config/device
         {{- end }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
@@ -98,5 +105,17 @@ spec:
         {{- end }}
         {{- if .Values.resources }}
         resources:
-          {{- toYaml .Values.resources | nindent 10}}
+          {{- toYaml .Values.resources | trim | nindent 10 }}
         {{- end -}}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | trim | nindent 8 }}
+      {{- end }}

--- a/emulator/templates/service.yaml
+++ b/emulator/templates/service.yaml
@@ -4,17 +4,24 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     synse-component: plugin
-    {{- include "labels" . | nindent 4 }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
-spec:
-  {{ if .Values.service.type -}}
-  {{ .Values.service.type }}
+    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
   {{- end }}
+spec:
+  clusterIP: None
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http
     name: http
   selector:
     synse-component: plugin
-    {{- include "selector" . | nindent 4 }}
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -2,15 +2,30 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-## Deployment replication configuration.
-replicaCount: 1
+
+## Partially override the fullname template (will maintain the release name).
+nameOverride: ""
+
+## Fully override the fullname template.
+fullnameOverride: ""
 
 ## Image configuration options.
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "3.0.0-alpha.5"
+  tag: "3.0.0-alpha.8"
   pullPolicy: Always
+
+## Deployment configuration options.
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Pod configuration options.
+pod:
+  annotations: {}
+  labels: {}
 
 ## Service configurations for the emulator plugin.
 ## ref: http://kubernetes.io/docs/user-guide/services/
@@ -18,21 +33,9 @@ image:
 ## The port here should match the network address in the
 ## plugin configuration, below.
 service:
-  type: "clusterIP: None"
+  annotations: {}
+  labels: {}
   port: 5001
-
-## Configure resource requests and limits.
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources:
-  requests:
-   cpu: 33m
-   memory: 150Mi
-
-## Pass arguments to the plugin container. For additional startup
-## logging, you can pass the --debug flag. By default, no additional
-## arguments are passed to the container.
-#args: ["--debug"]
-args: []
 
 ## Readiness and liveness probe configuration options
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -47,6 +50,33 @@ readinessProbe:
   timeoutSeconds: 2
   periodSeconds: 5
 
+## Pass arguments to the plugin container. For additional startup
+## logging, you can pass the --debug flag. By default, no additional
+## arguments are passed to the container.
+#args: ["--debug"]
+args: []
+
+## Allow pass-through environment variable configuration.
+env: {}
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests: {}
+  limits: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Synse Emulator Plugin configuration.
 ## The emulator plugin image comes pre-built with a default sane configuration.
 ## The block below may be uncommented if a custom configuration is desired.
@@ -56,8 +86,9 @@ readinessProbe:
 #  network:
 #    type: tcp
 #    address: ":5001"
+config: {}
 
 ## Synse Emulator device configurations. If no device configurations
 ## are specified here, the emulator will use the default built-in
 ## configurations.
-#devices: {}
+devices: {}


### PR DESCRIPTION
This PR:
- bumps the chart to 3.0.0-alpha.6 and the app version to 3.0.0-alpha.8
- documents configurable values in the README
- general chart updates and cleanup to make things more flexible (e.g. add affinity, tolerations, nodeSelector, etc) and more explicit (e.g. not using template for labels/annotations/selectors, etc).
- reorganizes some of the options in values.yaml 
- updates NOTES.txt to not just wholesale dump the entire values config which everyone ignores, but instead just print out the chart/app version. may or may not be useful, but its not a wall of config that gets ignored anyways.
- cleans up how the configs get mounted in. need to use a subpath for the plugin config so the volume mounting doesn't wipe away the devices dir (see: https://hackernoon.com/mount-file-to-kubernetes-pod-without-deleting-the-existing-file-in-the-docker-container-in-the-88b5d11661a6). I think this is okay. While Kubernetes docs note that:
    > A Container using a ConfigMap as a subPath volume mount will not receive ConfigMap updates. 
    -- (https://kubernetes.io/docs/concepts/storage/volumes/#configmap)

    I think that because we have the annotation which hashes the configmap contents to force restart, this is fine..
   