### PR TITLE
[emulator] bump application version to 3.0.0-alpha.9

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: emulator
-version: 3.0.0-alpha.6
-appVersion: 3.0.0-alpha.8
+version: 3.0.0-alpha.7
+appVersion: 3.0.0-alpha.9
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Synse Emulator Plug
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/emulator-plugin` |
-| `image.tag` | The tag of the image to use. | `3.0.0-alpha.8` |
+| `image.tag` | The tag of the image to use. | `3.0.0-alpha.9` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "3.0.0-alpha.8"
+  tag: "3.0.0-alpha.9"
   pullPolicy: Always
 
 ## Deployment configuration options.


### PR DESCRIPTION
This PR:
- bumps the application version to 3.0.0-alpha.9, which expands upon the returned readings for the fan device