### PR TITLE
[synse-server] update NOTES.txt to be less noisy

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.8
+version: 3.0.0-alpha.9
 appVersion: 3.0.0-alpha.8
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
@@ -12,4 +12,3 @@ maintainers:
     email: erick@vapor.io
   - name: Marco Ceppi
     email: marco@vapor.io
-engine: gotpl

--- a/synse-server/templates/NOTES.txt
+++ b/synse-server/templates/NOTES.txt
@@ -1,3 +1,4 @@
-Current Configuration:
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}
 
-{{ toYaml .Values | indent 4 }}


### PR DESCRIPTION
This PR:
- removes the `engine` field in the Chart, since we are just specifying the default
- tidies up the output from NOTES.txt so it is less noisy and perhaps more useful
- bumps the chart version to 3.0.0-alpha.9