### PR TITLE
[synse-server] bump image version to v3.0.0-alpha.9

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.9
-appVersion: 3.0.0-alpha.8
+version: 3.0.0-alpha.10
+appVersion: 3.0.0-alpha.9
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Synse Server chart 
 | `rbac.create` | Create RBAC resources and a ServiceAccount for the Synse Server deployment to use. This must be done if Synse Server is configured to use plugin discovery via Kubernetes endpoints. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/synse-server` |
-| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.8` |
+| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.9` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -21,7 +21,7 @@ rbac:
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
-  tag: "v3.0.0-alpha.8"
+  tag: "v3.0.0-alpha.9"
   pullPolicy: Always
 
 ## Deployment configuration options.


### PR DESCRIPTION
This PR:
- bumps the synse-server image version to `v3.0.0-alpha.9`