### PR TITLE
[synse-server] add option to enable/disable application metrics export

### DIFF
--- a/etamay/Chart.yaml
+++ b/etamay/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: etamay
 version: 1.0.0
 appVersion: 0.1.0

--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,5 +1,4 @@
----
-
+apiVersion: v1
 name: modbus
 version: 0.2.1
 appVersion: 1.1.1

--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,5 +1,4 @@
----
-
+apiVersion: v1
 name: snmp
 version: 0.1.1
 appVersion: 1.1.1

--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.10
-appVersion: 3.0.0-alpha.9
+version: 3.0.0-alpha.11
+appVersion: 3.0.0-alpha.10
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -45,9 +45,10 @@ The following table lists the configurable parameters of the Synse Server chart 
 | `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `rbac.create` | Create RBAC resources and a ServiceAccount for the Synse Server deployment to use. This must be done if Synse Server is configured to use plugin discovery via Kubernetes endpoints. | `false` |
+| `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/synse-server` |
-| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.9` |
+| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.10` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/synse-server/templates/deployment.yaml
+++ b/synse-server/templates/deployment.yaml
@@ -58,10 +58,12 @@ spec:
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
-        {{- if .Values.env }}
         env:
+          - name: SYNSE_METRICS_ENABLED
+            value: {{ .Values.metrics.enabled | quote }}
+          {{- if .Values.env }}
           {{- toYaml .Values.env | trim | nindent 10 }}
-        {{- end }}
+          {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         {{- with .Values.livenessProbe }}
         livenessProbe:

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -17,11 +17,15 @@ fullnameOverride: ""
 rbac:
   create: false
 
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
 ## Image configuration options.
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
-  tag: "v3.0.0-alpha.9"
+  tag: "v3.0.0-alpha.10"
   pullPolicy: Always
 
 ## Deployment configuration options.


### PR DESCRIPTION
This PR:
- bumps the synse-server chart to use the 3.0.0-alpha.10 image
- adds a value configuration for enabling/disabling application metrics export
- sets environment variable based on configured value