### PR TITLE
Chart api versions

### DIFF
--- a/etamay/Chart.yaml
+++ b/etamay/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: etamay
 version: 1.0.0
 appVersion: 0.1.0

--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,5 +1,4 @@
----
-
+apiVersion: v1
 name: modbus
 version: 0.2.1
 appVersion: 1.1.1

--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,5 +1,4 @@
----
-
+apiVersion: v1
 name: snmp
 version: 0.1.1
 appVersion: 1.1.1


### PR DESCRIPTION
This PR:
- adds the `apiVersion` field to Charts which are missing them

fixes #55