### PR TITLE
[emulator] add option to enable/disable application metrics export

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: emulator
-version: 3.0.0-alpha.7
-appVersion: 3.0.0-alpha.9
+version: 3.0.0-alpha.8
+appVersion: 3.0.0-alpha.10
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -45,9 +45,10 @@ The following table lists the configurable parameters of the Synse Emulator Plug
 | `devices` | Custom emulator devices configuration. If this is not set, the default built-in device configs are used.| `{}` |
 | `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
 | `fullnameOverride` | Fully override the fullname template. | `""` |
+| `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/emulator-plugin` |
-| `image.tag` | The tag of the image to use. | `3.0.0-alpha.9` |
+| `image.tag` | The tag of the image to use. | `3.0.0-alpha.10` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/emulator/templates/deployment.yaml
+++ b/emulator/templates/deployment.yaml
@@ -60,13 +60,19 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: 2112
+        {{- end }}
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
-        {{- if .Values.env }}
         env:
+          - name: PLUGIN_METRICS_ENABLED
+            value: {{ .Values.metrics.enabled | quote }}
+          {{- if .Values.env }}
           {{- toYaml .Values.env | trim | nindent 10 }}
-        {{- end }}
+          {{- end }}
         {{- if (or .Values.config .Values.devices) }}
         volumeMounts:
         {{- if .Values.config }}

--- a/emulator/templates/service.yaml
+++ b/emulator/templates/service.yaml
@@ -21,6 +21,11 @@ spec:
   - port: {{ .Values.service.port }}
     targetPort: http
     name: http
+  {{- if .Values.metrics.enabled }}
+  - port: 2112
+    targetPort: metrics
+    name: metrics
+  {{- end }}
   selector:
     synse-component: plugin
     app: {{ template "name" . }}

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -13,8 +13,12 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "3.0.0-alpha.9"
+  tag: "3.0.0-alpha.10"
   pullPolicy: Always
+
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
 
 ## Deployment configuration options.
 deployment:


### PR DESCRIPTION
This PR:
- bumps the chart to 3.0.0-alpha.8
- bumps the image version to 3.0.0-alpha.10
- adds config for enabling/disabling metrics export via prometheus (`:2112/metrics`)