### PR TITLE
[snmp] re-cycle deployments when configmap changes

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: snmp
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.1.1
 description: snmp
 home: https://github.com/vapor-ware/synse-snmp-plugin.git

--- a/snmp/templates/deployment.yaml
+++ b/snmp/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
 {{ include "labels" . | indent 8 }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "annotations" . | indent 8 }}
     spec:
       # Setting the hostname because the UPSs only take communications from specific hostnames.


### PR DESCRIPTION
This will make sure that if we change SNMP configuration that the pods will re-cycle to get the changes