### PR TITLE
[modbus] chart improvements and updates for v3 plugin

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,12 +1,16 @@
 apiVersion: v1
 name: modbus
-version: 0.2.1
-appVersion: 1.1.1
-description: Synse Modbus over IP Plugin.
+version: 1.0.0
+appVersion: 3.0.0-alpha.1
+description: Modbus over IP pluign for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin
 icon: https://charts.vapor.io/.images/synse-modbus.jpg
+sources:
+  - https://github.com/vapor-ware/synse-modbus-ip-plugin.git
 maintainers:
 - name: Matthew Hink
   email: mhink@vapor.io
 - name: Marco Ceppi
   email: marco@vapor.io
+- name: Erick Daniszewski
+  email: erick@vapor.io

--- a/modbus/README.md
+++ b/modbus/README.md
@@ -1,0 +1,75 @@
+# Modbus IP Plugin
+
+The [Synse Modbus IP Plugin](https://github.com/vapor-ware/synse-modbus-ip-plugin) is a Synse plugin
+which provides generic support for reading and writing to modbus devices over IP.
+
+## TL;DR;
+
+```bash
+$ helm install synse/modbus
+```
+
+## Introduction
+
+This chart bootstraps a [Synse Modbus IP Plugin](https://github.com/vapor-ware/synse-modbus-ip-plugin)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release synse/modbus
+```
+
+The command deploys a Synse Modbus IP Plugin on the Kubernetes cluster in the default configuration. The
+[configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Synse Modbus Plugin chart and their default values.
+
+| Parameter | Description | Default |
+| :-------- | :---------- | :------ |
+| `config` | The Modbus Plugin configuration. | `{}` |
+| `devices` | Configuration for the modbus devices which the plugin should interface with. | `{}` |
+| `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
+| `fullnameOverride` | Fully override the fullname template. | `""` |
+| `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
+| `image.registry` | The image registry to use. | `""` |
+| `image.repository` | The name of the image to use. | `vaporio/modbus-ip-plugin` |
+| `image.tag` | The tag of the image to use. | `3.0.0-alpha.1` |
+| `image.pullPolicy` | The image pull policy. | `Always` |
+| `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
+| `deployment.labels` | Additional labels for the Deployment. | `{}` |
+| `deployment.replicas` | The number of replicas to deploy with. | `1` |
+| `pod.annotations` | Additional annotations for the Pod. | `{}` |
+| `pod.labels` | Additional labels for the Pod. | `{}` |
+| `service.annotations` | Additional annotations for the Service. | `{}` |
+| `service.labels` | Additional labels for the Service. | `{}` |
+| `service.port` | The Service port to expose. | `5004` |
+| `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
+| `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `30` |
+| `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `5` |
+| `livenessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `readinessProbe.enabled` | Enable/disable the readiness probe check. | `true` |
+| `readinessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `5` |
+| `readinessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `readinessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `args` | Additional arguments to pass to the container. | `[]` |
+| `env` | Additional environment variables to set for the container. This may be used for configuring the plugin as well. | `{}` |
+| `resources.requests` | Pod requests resources. | `{}` |
+| `resources.limits` | Pod limits resources. | `{}` |
+| `nodeSelector` | Node labels for Pod assignment. | `{}` |
+| `tolerations` | Node taints to tolerate. | `[]` |
+| `affinity` | Pod affinity. | `{}` |

--- a/modbus/templates/NOTES.txt
+++ b/modbus/templates/NOTES.txt
@@ -1,3 +1,3 @@
-Current Configuration:
-
-{{ toYaml .Values | indent 4 }}
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}

--- a/modbus/templates/_helpers.tpl
+++ b/modbus/templates/_helpers.tpl
@@ -1,36 +1,32 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Expand the name of the chart.
+  Expand the name of the chart.
 */}}
 {{- define "name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+  Create a default fully qualified app name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  If release name contains chart name it will be used as a full name.
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-# Output the common labels used.
-{{- define "labels" -}}
-{{ template "selector" . }}
-heritage: {{ .Release.Service | quote }}
+{{- end -}}
 {{- end -}}
 
-{{- define "annotations" -}}
-chart: "{{ .Chart.Name }}"
-{{- end -}}
-
-# Selector to pick a specific release/app.
-{{- define "selector" -}}
-app: {{ include "name" . | quote }}
-release: {{ .Release.Name | quote }}
-{{- if .Values.component }}
-component: {{ .Values.component }}
-{{- end -}}
+{{/*
+  Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/modbus/templates/configmap.yaml
+++ b/modbus/templates/configmap.yaml
@@ -1,27 +1,34 @@
-# Modbus TCP/IP plugin configuration
+{{- if (or .Values.config .Values.devices) }}
+{{- if .Values.config }}
+# Plugin configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "name" . }}-plugin
+  name: {{ template "fullname" . }}-config
   labels:
-{{ include "labels" . | indent 4 }}
-  annotations:
-{{ include "annotations" . | indent 4 }}
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
-  {{- if .Values.config }}
   config.yml: {{ toYaml .Values.config | quote }}
-  {{- end }}
+{{- end }}
+{{- if .Values.devices }}
 ---
-# Modbus TCP/IP device configuration
+
+# Device configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "name" . }}-devices
+  name: {{ template "fullname" . }}-devices
   labels:
-{{ include "labels" . | indent 4 }}
-  annotations:
-{{ include "annotations" . | indent 4 }}
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
-  {{- if .Values.devices }}
   config.yml: {{ toYaml .Values.devices | quote }}
-  {{- end }}
+{{- end }}
+{{- end }}

--- a/modbus/templates/deployment.yaml
+++ b/modbus/templates/deployment.yaml
@@ -3,30 +3,56 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-{{ include "labels" . | indent 4 }}
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
   annotations:
-{{ include "annotations" . | indent 4 }}
+    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+  {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-{{ include "selector" . | indent 6 }}
+      synse-component: plugin
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       name: {{ template "fullname" . }}
       labels:
-{{ include "labels" . | indent 8 }}
+        synse-component: plugin
+        app: {{ template "name" . }}
+        chart: {{ template "chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- end }}
       annotations:
-{{ include "annotations" . | indent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.pod.annotations }}
+        {{- toYaml .Values.pod.annotations | trim | nindent 8}}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 3
+      {{- if (or .Values.config .Values.devices) }}
       volumes:
-      - name: plugin-config
-        configMap:
-          name: {{ template "name" . }}-plugin
-      - name: device-config
-        configMap:
-          name: {{ template "name" . }}-devices
+        {{- if .Values.config }}
+        - name: config
+          configMap:
+            name: {{ template "fullname" . }}-config
+        {{- end }}
+        {{- if .Values.devices }}
+        - name: devices
+          configMap:
+            name: {{ template "fullname" . }}-devices
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -34,15 +60,69 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: 2112
+        {{- end }}
         {{- if .Values.args }}
         args: {{ .Values.args }}
         {{- end }}
+        env:
+          - name: PLUGIN_METRICS_ENABLED
+            value: {{ .Values.metrics.enabled | quote }}
+          {{- if .Values.env }}
+          {{- toYaml .Values.env | trim | nindent 10 }}
+          {{- end }}
+        {{- if (or .Values.config .Values.devices) }}
         volumeMounts:
-        - name: plugin-config
-          mountPath: /etc/synse/plugin/config
-        - name: device-config
-          mountPath: /etc/synse/plugin/config/device
-        {{ if .Values.resources -}}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.config }}
+        - name: config
+          mountPath: /etc/synse/plugin/config/config.yml
+          subPath: config.yml
         {{- end }}
+        {{- if .Values.devices }}
+        - name: devices
+          mountPath: /etc/synse/plugin/config/device
+        {{- end }}
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        {{- with .Values.livenessProbe }}
+        livenessProbe:
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          exec:
+            command:
+              - /bin/exists
+              - /etc/synse/plugin/healthy
+        {{- end }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          exec:
+            command:
+              - /bin/exists
+              - /etc/synse/plugin/healthy
+        {{- end }}
+        {{- end }}
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
+        {{- end -}}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | trim | nindent 8 }}
+      {{- end }}
+

--- a/modbus/templates/service.yaml
+++ b/modbus/templates/service.yaml
@@ -3,16 +3,30 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-{{ include "labels" . | indent 4 }}
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
   annotations:
-{{ include "annotations" . | indent 4 }}
-spec:
-  {{ if .Values.service.type -}}
-  {{ .Values.service.type }}
+    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
   {{- end }}
+spec:
+  clusterIP: None
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http
     name: http
+  {{- if .Values.metrics.enabled }}
+  - port: 2112
+    targetPort: metrics
+    name: metrics
+  {{- end }}
   selector:
-{{ include "selector" . | indent 4 }}
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -2,28 +2,56 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
 
+## Partially override the fullname template (will maintain the release name).
+nameOverride: ""
+
+## Fully override the fullname template.
+fullnameOverride: ""
+
+## Image configuration options.
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/modbus-ip-plugin
-  tag: "1.1.1"
+  tag: "3.0.0-alpha.1"
   pullPolicy: Always
 
-## Service configurations for the modbus plugin.
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
+## Deployment configuration options.
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Pod configuration options.
+pod:
+  annotations: {}
+  labels: {}
+
+## Service configuration options.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 ##
 ## The port defined here should match the plugin configuration, below.
 service:
-  type: "clusterIP: None"
+  annotations: {}
+  labels: {}
   port: 5004
 
-## Configure resource requests and limits.
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources:
-  requests:
-    cpu: 33m
-    memory: 150Mi
+## Readiness and liveness probe configuration options
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  periodSeconds: 5
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  timeoutSeconds: 2
+  periodSeconds: 5
 
 ## Pass arguments to the plugin container. For additional startup
 ## logging, you can pass the --debug flag. By default, no additional
@@ -31,26 +59,44 @@ resources:
 #args: ["--debug"]
 args: []
 
-## Component type
-component: plugin
+## Allow pass-through environment variable configuration.
+env: {}
 
-## Default plugin configuration. If a deployment needs to modify the plugin config, it will
-## need to specify the whole config -- it cannot just override single fields.
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests: {}
+  limits: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Plugin configuration
+## The configuration below specifies a basic default configuration for the plugin.
+## Deployments which require anything different than this basic configuration will
+## need to specify their own config wholesale - single fields may not be overridden
+## from this config block.
 config:
-  version: 1.1
+  version: 3
   debug: true
-  # The network info here should match the Service configuration
   network:
     type: tcp
-    address: "0.0.0.0:5004"
+    address: ":5004"
   settings:
-    mode: serial # Parallel will overwhelm the VEM PLC.
+    mode: serial
     read:
       interval: 5s
-      write:
-        enable: true
 
 ## Device configuration
-## Each site should define its own device configuration since this may
-## change from site to site depending on what is actually deployed.
+## Each instance should define its own device configuration. This may be different
+## per deployment depending on what physical assets are available.
 devices: {}


### PR DESCRIPTION
This PR:
- updates the modbus chart definitions, allowing it to be more flexible/configurable and better documented


~Some of the changes here are specific for the v3 version of the modbus image, so I'm opening this as a draft for initial review. Once v3 lands, this PR can be converted into a regular PR.~

https://github.com/vapor-ware/synse-modbus-ip-plugin/releases/tag/3.0.0-alpha.1