### PR TITLE
[synse-server] bump application to v3.0.0-alpha.14

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-server
-version: 3.0.0-alpha.14
-appVersion: 3.0.0-alpha.13
+version: 3.0.0-alpha.15
+appVersion: 3.0.0-alpha.14
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse Server chart 
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/synse-server` |
-| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.13` |
+| `image.tag` | The tag of the image to use. | `v3.0.0-alpha.14` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/synse-server/values.yaml
+++ b/synse-server/values.yaml
@@ -25,7 +25,7 @@ metrics:
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-server
-  tag: "v3.0.0-alpha.13"
+  tag: "v3.0.0-alpha.14"
   pullPolicy: Always
 
 ## Deployment configuration options.


### PR DESCRIPTION
This PR:
- bumps the synse-server chart to use application version [v3.0.0-alpha.14](https://github.com/vapor-ware/synse-server/compare/v3.0.0-alpha.13...v3.0.0-alpha.14)