### PR TITLE
[modbus] enable plugin cache by default

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: modbus
-version: 1.0.0
+version: 1.0.1-alpha.1
 appVersion: 3.0.0-alpha.1
 description: Modbus over IP pluign for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -95,6 +95,9 @@ config:
     mode: serial
     read:
       interval: 5s
+    cache:
+      enabled: true
+      ttl: 5m
 
 ## Device configuration
 ## Each instance should define its own device configuration. This may be different


### PR DESCRIPTION
This PR:
- updates the modbus plugin config to enable the plugin cache by default (locally caches reading values for 5min; this give more context for synse's `/readcache` endpoint)
- bumps chart version to `1.0.1-alpha.1`. I accidentally set the version to `1.0.0` before instead of `1.0.0-alpha.1`, so I just bumped the patch version and added the alpha.