### PR TITLE
[snmp] bump app to 2.0.0

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snmp
-version: 1.0.1
-appVersion: 3.0.0-alpha.7
+version: 2.0.0
+appVersion: 2.0.0
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse SNMP Plugin c
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/snmp-plugin` |
-| `image.tag` | The tag of the image to use. | `3.0.0-alpha.1` |
+| `image.tag` | The tag of the image to use. | `2.0.0` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/snmp-plugin
-  tag: "3.0.0-alpha.7"
+  tag: "2.0.0"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
This PR:
- bumps the app version to 2.0.0
- bumps the chart version to 2.0.0 -- I'm not sure that it needs to be a major version bump here, but it feels a little weird releasing a new major image version as chart version `1.0.2` or `1.1.0`. However, I'm not married to it, so if there are dissenting opinions, I can change the chart version.