### PR TITLE
[synse-loadgen] bump app to version 1.0.1

### DIFF
--- a/synse-loadgen/Chart.yaml
+++ b/synse-loadgen/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: synse-loadgen
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 description: Generate request loads against the Synse Server API
 home: https://github.com/vapor-ware/synse-loadgen
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-loadgen/README.md
+++ b/synse-loadgen/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse LoadGen chart
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/synse-loadgen` |
-| `image.tag` | The tag of the image to use. | `1.0.0` |
+| `image.tag` | The tag of the image to use. | `1.0.1` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/synse-loadgen/values.yaml
+++ b/synse-loadgen/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/synse-loadgen
-  tag: "1.0.0"
+  tag: "1.0.1"
   pullPolicy: Always
 
 ## Deployment configuration options.


### PR DESCRIPTION
This PR:
- bumps synse-loadgen to 1.0.1
- bumps the chart to 1.0.1

https://github.com/vapor-ware/synse-loadgen/releases/tag/1.0.1