### PR TITLE
[snmp-ups] initial commit of the snmp-ups chart definition

### DIFF
--- a/snmp-ups/.helmignore
+++ b/snmp-ups/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/snmp-ups/Chart.yaml
+++ b/snmp-ups/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: snmp-ups
+version: 0.1.0
+appVersion: 0.1.0
+description: SNMP plugin the RFC1628 UPS MIB
+home: https://github.com/vapor-ware/synse-snmp-ups-plugin
+icon: https://charts.vapor.io/.images/synse-snmp.jpg
+sources:
+  - https://github.com/vapor-ware/synse-snmp-ups-plugin.git
+maintainers:
+- name: Matthew Hink
+  email: mhink@vapor.io
+- name: Marco Ceppi
+  email: marco@vapor.io
+- name: Erick Daniszewski
+  email: erick@vapor.io

--- a/snmp-ups/README.md
+++ b/snmp-ups/README.md
@@ -1,0 +1,76 @@
+# Synse SNMP Plugin
+
+The [Synse SNMP UPS Plugin](https://github.com/vapor-ware/synse-snmp-ups-plugin) is a Synse plugin
+which provides SNMP support for UPS devices following the RFC1628 MIB definition.
+
+## TL;DR;
+
+```bash
+$ helm install synse/snmp-ups
+```
+
+## Introduction
+
+This chart bootstraps a [Synse SNMP UPS Plugin](https://github.com/vapor-ware/synse-snmp-ups-plugin)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release synse/snmp-ups
+```
+
+The command deploys a Synse SNMP UPS Plugin on the Kubernetes cluster in the default configuration. The
+[configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Synse SNMP UPS Plugin chart and their default values.
+
+| Parameter | Description | Default |
+| :-------- | :---------- | :------ |
+| `config` | The SNMP UPS Plugin configuration. | `{}` |
+| `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
+| `fullnameOverride` | Fully override the fullname template. | `""` |
+| `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
+| `image.registry` | The image registry to use. | `""` |
+| `image.repository` | The name of the image to use. | `vaporio/snmp-ups-plugin` |
+| `image.tag` | The tag of the image to use. | `0.1.0` |
+| `image.pullPolicy` | The image pull policy. | `Always` |
+| `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
+| `deployment.labels` | Additional labels for the Deployment. | `{}` |
+| `deployment.replicas` | The number of replicas to deploy with. | `1` |
+| `pod.annotations` | Additional annotations for the Pod. | `{}` |
+| `pod.labels` | Additional labels for the Pod. | `{}` |
+| `pod.hostname` | The hostname to use for the Pod. | `""` |
+| `pod.securityContext` | Privilege and access control settings for the Pod. | `{}` |
+| `service.annotations` | Additional annotations for the Service. | `{}` |
+| `service.labels` | Additional labels for the Service. | `{}` |
+| `service.port` | The Service port to expose. | `5003` |
+| `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
+| `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `30` |
+| `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `5` |
+| `livenessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `readinessProbe.enabled` | Enable/disable the readiness probe check. | `true` |
+| `readinessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `5` |
+| `readinessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `readinessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `args` | Additional arguments to pass to the container. | `[]` |
+| `env` | Additional environment variables to set for the container. This may be used for configuring the plugin as well. | `{}` |
+| `resources.requests` | Pod requests resources. | `{}` |
+| `resources.limits` | Pod limits resources. | `{}` |
+| `nodeSelector` | Node labels for Pod assignment. | `{}` |
+| `tolerations` | Node taints to tolerate. | `[]` |
+| `affinity` | Pod affinity. | `{}` |

--- a/snmp-ups/templates/NOTES.txt
+++ b/snmp-ups/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}

--- a/snmp-ups/templates/_helpers.tpl
+++ b/snmp-ups/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+  Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+  Create a default fully qualified app name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/snmp-ups/templates/configmap.yaml
+++ b/snmp-ups/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.config }}
+# Plugin configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yml: {{ toYaml .Values.config | quote }}
+{{- end }}

--- a/snmp-ups/templates/deployment.yaml
+++ b/snmp-ups/templates/deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      synse-component: plugin
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        synse-component: plugin
+        app: {{ template "name" . }}
+        chart: {{ template "chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.pod.annotations }}
+        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.pod.hostname }}
+      # Set the hostname for the pod. This may be required for SNMP devices which only allow
+      # communication from specific hostnames.
+      hostname: {{ .Values.pod.hostname }}
+      {{- end }}
+      terminationGracePeriodSeconds: 3
+      {{- if .Values.config }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "fullname" .  }}-config
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.pod.securityContext }}
+        securityContext:
+          {{- toYaml .Values.pod.securityContext | trim | nindent 10 }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.port }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: 2112
+        {{- end }}
+        {{- if .Values.args }}
+        args: {{ .Values.args }}
+        {{- end }}
+        env:
+          - name: PLUGIN_METRICS_ENABLED
+            value: {{ .Values.metrics.enabled | quote }}
+          {{- if .Values.env }}
+          {{- toYaml .Values.env | trim | nindent 10 }}
+          {{- end }}
+        {{- if .Values.config }}
+        volumeMounts:
+          - name: config
+            mountPath: /etc/synse/plugin/config/config.yml
+            subPath: config.yml
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        {{- with .Values.livenessProbe }}
+        livenessProbe:
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          exec:
+            command:
+              - /bin/exists
+              - /etc/synse/plugin/healthy
+        {{- end }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          initialDelaySeconds: {{ .initialDelaySeconds }}
+          timeoutSeconds: {{ .timeoutSeconds }}
+          periodSeconds: {{ .periodSeconds }}
+          exec:
+            command:
+              - /bin/exists
+              - /etc/synse/plugin/healthy
+        {{- end }}
+        {{- end }}
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
+        {{- end -}}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | trim | nindent 8 }}
+      {{- end }}

--- a/snmp-ups/templates/service.yaml
+++ b/snmp-ups/templates/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    name: http
+  {{- if .Values.metrics.enabled }}
+  - port: 2112
+    targetPort: metrics
+    name: metrics
+  {{- end }}
+  selector:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/snmp-ups/values.yaml
+++ b/snmp-ups/values.yaml
@@ -1,0 +1,112 @@
+# Default values for the SNMP UPS plugin.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Partially override the fullname template (will maintain the release name).
+nameOverride: ""
+
+## Fully override the fullname template.
+fullnameOverride: ""
+
+## Image configuration options.
+image:
+  registry: "" # Add a registry if we need to use the non-default one
+  repository: vaporio/snmp-ups-plugin
+  tag: "0.1.0"
+  pullPolicy: Always
+
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
+## Deployment configuration options.
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Pod configuration options.
+pod:
+  annotations: {}
+  labels: {}
+  hostname: ""
+
+  ## Privilege and access control settings for the Pod
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext:
+    privileged: false
+
+## Service configuration options.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+## The port defined here should match the plugin configuration, below.
+service:
+  annotations: {}
+  labels: {}
+  port: 5003
+
+## Readiness and liveness probe configuration options
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  periodSeconds: 5
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  timeoutSeconds: 2
+  periodSeconds: 5
+
+## Pass arguments to the plugin container. For additional startup
+## logging, you can pass the --debug flag. By default, no additional
+## arguments are passed to the container.
+#args: ["--debug"]
+args: []
+
+## Allow pass-through environment variable configuration.
+env: {}
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests: {}
+  limits: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Plugin configuration
+## The configuration below specifies a basic default configuration for the plugin.
+## Deployments which require anything different than this basic configuration will
+## need to specify their own config wholesale - single fields may not be overridden
+## from this config block.
+##
+## If the plugin will use dynamic configuration, this should be set here, under the
+## `dynamicRegistration` config option. See the SDK documentation and plugin README
+## for more details.
+##
+#config:
+#  version: 3
+#  debug: true
+#  network:
+#    type: tcp
+#    address: ":5003"
+#  settings:
+#    mode: serial
+#    read:
+#      interval: 3s
+#      buffer: 1024
+#    write:
+#      # The SNMP plugin does not currently support writes
+#      enabled: false
+config: {}


### PR DESCRIPTION
This PR:
- adds the initial definitions for the synse snmp ups plugin chart


~This is currently a WIP as the plugin work is completed and the correct version is cut. I don't anticipate any changes to the chart in relation to the outstanding work for the plugin.~