### PR TITLE
[emulator] bump app version to 3.0.2

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: emulator
-version: 3.0.0
-appVersion: 3.0.0
+version: 3.0.1
+appVersion: 3.0.2
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin
 icon: https://charts.vapor.io/.images/synse-emulator.jpg

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse Emulator Plug
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/emulator-plugin` |
-| `image.tag` | The tag of the image to use. | `3.0.0` |
+| `image.tag` | The tag of the image to use. | `3.0.2` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/emulator-plugin
-  tag: "3.0.0"
+  tag: "3.0.2"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
This PR:
- bumps  the emulator app  version to  3.0.2
- bumps the chart version to 3.0.1

https://github.com/vapor-ware/synse-emulator-plugin/releases/tag/3.0.2