### PR TITLE
[juniper-jti] initial commit of the juniper-jti chart (0.1.0)

### DIFF
--- a/juniper-jti/.helmignore
+++ b/juniper-jti/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: juniper-jti
+version: 0.1.0
+appVersion: 0.1.0
+description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
+home: https://github.com/vapor-ware/synse-juniper-jti-plugin
+icon: https://charts.vapor.io/.images/synse-server-chart.jpg
+sources:
+  - https://github.com/vapor-ware/synse-juniper-jti-plugin.git
+maintainers:
+  - name: Erick Daniszewski
+    email: erick@vapor.io

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -60,6 +60,16 @@ The following table lists the configurable parameters of the Synse Juniper JTI P
 | `service.annotations` | Additional annotations for the Service. | `{}` |
 | `service.labels` | Additional labels for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5010` |
+| `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `juniper_jti_monitor` |
+| `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
+| `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
+| `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |
+| `monitoring.serviceMonitor.path` | The url segment to append to the discovered service endpoint. (eg: /metrics) | `"/metrics"` |
+| `monitoring.serviceMonitor.port` | The network port to attempt to connect to. Named ports are preferred, but numeric port numbers will work. | `"metrics"` |
+| `monitoring.serviceMonitor.timeout` | Timeout, in seconds, to terminate a scrape and classify as failed. | `"4s"` |
+| `monitoring.serviceMonitor.interval` | How often to scrape the metric data. | `"5s"` |
+| `monitoring.serviceMonitor.labels` | Labels to apply to the ServiceMonitor. | `{}` |
 | `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
 | `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `15` |
 | `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the Synse Juniper JTI P
 | `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
+| `udpServer.port` | The port to expose for the UDP server receiving streamed JTI data. | `""` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/juniper-jti-plugin` |
 | `image.tag` | The tag of the image to use. | `0.1.0` |

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -1,0 +1,75 @@
+# Synse Juniper JTI Plugin
+
+The [Synse Juniper JTI Plugin](https://github.com/vapor-ware/synse-juniper-jti-plugin) is a Synse plugin
+which provides networking data from Juniper JTI data streams. 
+
+## TL;DR;
+
+```bash
+$ helm install synse/juniper-jti
+```
+
+## Introduction
+
+This chart bootstraps a [Synse Juniper JTI Plugin](https://github.com/vapor-ware/synse-juniper-jti-plugin)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release synse/juniper-jti
+```
+
+The command deploys a Synse Juniper JTI Plugin on the Kubernetes cluster in the default configuration. The
+[configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Synse Juniper JTI Plugin chart and their default values.
+
+| Parameter | Description | Default |
+| :-------- | :---------- | :------ |
+| `config` | The Juniper JTI Plugin configuration. | `{}` |
+| `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
+| `fullnameOverride` | Fully override the fullname template. | `""` |
+| `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
+| `image.registry` | The image registry to use. | `""` |
+| `image.repository` | The name of the image to use. | `vaporio/juniper-jti-plugin` |
+| `image.tag` | The tag of the image to use. | `0.1.0` |
+| `image.pullPolicy` | The image pull policy. | `Always` |
+| `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
+| `deployment.labels` | Additional labels for the Deployment. | `{}` |
+| `deployment.replicas` | The number of replicas to deploy with. | `1` |
+| `pod.annotations` | Additional annotations for the Pod. | `{}` |
+| `pod.labels` | Additional labels for the Pod. | `{}` |
+| `pod.securityContext` | Pod security definitions. | `{}` |
+| `securityContext` | Security definitions for containers running in the Pod. | `{}` |
+| `service.annotations` | Additional annotations for the Service. | `{}` |
+| `service.labels` | Additional labels for the Service. | `{}` |
+| `service.port` | The Service port to expose. | `5010` |
+| `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
+| `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `15` |
+| `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `livenessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `readinessProbe.enabled` | Enable/disable the readiness probe check. | `true` |
+| `readinessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `5` |
+| `readinessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `2` |
+| `readinessProbe.periodSeconds` | The frequency with which the probe should run, in seconds. | `5` |
+| `args` | Additional arguments to pass to the container. | `[]` |
+| `env` | Additional environment variables to set for the container. This may be used for configuring the plugin as well. | `[]` |
+| `resources` | Pod resource restrictions. | `{}` |
+| `nodeSelector` | Node labels for Pod assignment. | `{}` |
+| `tolerations` | Node taints to tolerate. | `[]` |
+| `affinity` | Pod affinity. | `{}` |

--- a/juniper-jti/templates/NOTES.txt
+++ b/juniper-jti/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Chart.Name }}
+  chart: {{ .Chart.Version }}
+  app:   {{ .Chart.AppVersion }}

--- a/juniper-jti/templates/NOTES.txt
+++ b/juniper-jti/templates/NOTES.txt
@@ -1,3 +1,10 @@
 {{ .Chart.Name }}
   chart: {{ .Chart.Version }}
   app:   {{ .Chart.AppVersion }}
+{{- if empty .Values.udpServer.port }}
+
+WARNING: Error detected with Juniper JTI configuration. The value for
+  'udpServer.port' was not found, but is required. It should take the
+  same port value of the server address specified in the plugin's
+  'dynamicRegistration' block.
+{{- end }}

--- a/juniper-jti/templates/_helpers.tpl
+++ b/juniper-jti/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+  Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+  Create a default fully qualified app name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/juniper-jti/templates/configmap.yaml
+++ b/juniper-jti/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.config }}
+# Plugin configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yml: {{ toYaml .Values.config | quote }}
+{{- end }}

--- a/juniper-jti/templates/deployment.yaml
+++ b/juniper-jti/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
+            - name: udpServer
+              containerPort: {{ .Values.udpServer.port }}
+              protocol: UDP
             {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: 2112

--- a/juniper-jti/templates/deployment.yaml
+++ b/juniper-jti/templates/deployment.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fullname" . }}
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      synse-component: plugin
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        synse-component: plugin
+        app: {{ template "name" . }}
+        chart: {{ template "chart" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.pod.annotations }}
+        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: 3
+      securityContext:
+        {{- toYaml .Values.pod.securityContext | trim | nindent 8 }}
+      {{- if .Values.config }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "fullname" . }}-config
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | trim | nindent 12 }}
+          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 2112
+            {{- end }}
+          {{- if .Values.args }}
+          args: {{ .Values.args }}
+          {{- end }}
+          env:
+            - name: PLUGIN_METRICS_ENABLED
+              value: {{ .Values.metrics.enabled | quote }}
+            {{- if .Values.env }}
+            {{- toYaml .Values.env | trim | nindent 12}}
+            {{- end }}
+          {{- if .Values.config }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/synse/plugin/config/config.yml
+              subPath: config.yml
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+          {{- end }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+            {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | trim | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | trim | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -21,6 +21,10 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       name: http
+    - port: {{ .Values.udpServer.port }}
+      targetPort: udpServer
+      name: udpServer
+      protocol: UDP
     {{- if .Values.metrics.enabled }}
     - port: 2112
       targetPort: metrics

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - port: 2112
+      targetPort: metrics
+      name: metrics
+    {{- end }}
+  selector:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/juniper-jti/templates/servicemonitor.yaml
+++ b/juniper-jti/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.metrics.enabled .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.monitoring.serviceMonitor.name | default "juniper_jti_monitor" }}
+  {{- if .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.monitoring.serviceMonitor.labels }}
+    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
+    {{- if .Values.monitoring.serviceMonitor.path }}
+    path: {{ .Values.monitoring.serviceMonitor.path }}
+    {{- end }}
+    scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
+    targetPort: {{ .Values.monitoring.serviceMonitor.port }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "juniper_jti_monitor" }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- end }}
+{{- end }}

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -1,0 +1,107 @@
+# Default values for juniper-jti-plugin.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+## Partially override the fullname template (will maintain the release name).
+nameOverride: ""
+
+## Fully override the fullname template.
+fullnameOverride: ""
+
+## Image configuration options.
+image:
+  registry: "" # Add a registry if we need to use the non-default one
+  repository: vaporio/juniper-jti-plugin
+  tag: "0.1.0"
+  pullPolicy: Always
+
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
+## Deployment configuration options.
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Pod configuration options.
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+    # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Service configurations for the emulator plugin.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+## The port here should match the network address in the
+## plugin configuration, below.
+service:
+  port: 5010
+  annotations: {}
+  labels: {}
+
+## Readiness and liveness probe configuration options
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 15
+  timeoutSeconds: 2
+  periodSeconds: 5
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  timeoutSeconds: 2
+  periodSeconds: 5
+
+## Pass arguments to the plugin container. For additional startup
+## logging, you can pass the --debug flag. By default, no additional
+## arguments are passed to the container.
+#args: ["--debug"]
+args: []
+
+## Allow pass-through environment variable configuration.
+env: []
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Synse Plugin configuration.
+## The plugin requires a plugin configuration to be provided. This should be
+## specified on a per-release level. It is left empty here.
+#config:
+#  version: 3
+#  debug: true
+#  network:
+#    type: tcp
+#    address: ":5010"
+config: {}

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -20,6 +20,26 @@ image:
 metrics:
   enabled: false
 
+## Prometheus monitoring
+monitoring:
+  serviceMonitor:
+    enabled: false
+    name: juniper_jti_monitor
+    port: metrics
+    path: "/metrics"
+    timeout: 4s
+    interval: 5s
+
+    # Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups.
+    namespace: ""
+    # Which namespace the prometheus tooling should interrogate to find services and pods.
+    selectorNamespace: ""
+    # Labels used to select the services/pods to monitor.
+    selectorLabels: {}
+    # Labels applied to the ServiceMonitor.
+    labels: {}
+      #vapor.io/monitor: application
+
 ## Define the port which the plugin's UDP server is configured to listen on
 ## (via the `config` block). This is required in order to expose the port for
 ## incoming streamed JTI data.

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -20,6 +20,19 @@ image:
 metrics:
   enabled: false
 
+## Define the port which the plugin's UDP server is configured to listen on
+## (via the `config` block). This is required in order to expose the port for
+## incoming streamed JTI data.
+##
+## FIXME (etd): This is not an ideal way of defining this config, as it is
+##   a duplicate config option from what is listed in the `config` block,
+##   but there doesn't seem to be a clean, easy way of deduplicating the
+##   config, so for the initial version of the chart, this is okay. If this
+##   is missing in the configuration, a message will be printed out via
+##   NOTES.txt.
+udpServer:
+  port: ""
+
 ## Deployment configuration options.
 deployment:
   annotations: {}


### PR DESCRIPTION
This PR:
- adds in a Juniper JTI chart to the charts repo

~This  is  still a WIP~, as it depends on:
- [x]  the Juniper  JTI  plugin having a 0.1.0 release (https://github.com/vapor-ware/synse-juniper-jti-plugin/pull/4)
- [x] adding configuration to the values/templates to be able to properly expose the correct UDP port to allow  telemetry  to  stream to the plugin.

https://github.com/vapor-ware/synse-juniper-jti-plugin/releases/tag/0.1.0