### PR TITLE
[juniper-jti]  add basic support for NodePort service type

### DIFF
--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: juniper-jti
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -46,6 +46,7 @@ A value of `-` indicates no default is defined.
 | `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
+| `metrics.labels` | Additional labels for the metrics Service. This is used by the service monitor to target the exposed metrics port. | `{}` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/juniper-jti-plugin` |
 | `image.tag` | The tag of the image to use. | `0.1.0` |

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -38,6 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following table lists the configurable parameters of the Synse Juniper JTI Plugin chart and their default values.
+A value of `-` indicates no default is defined.
 
 | Parameter | Description | Default |
 | :-------- | :---------- | :------ |
@@ -45,7 +46,6 @@ The following table lists the configurable parameters of the Synse Juniper JTI P
 | `nameOverride` | Partially override the fullname template (will maintain the release name). | `""` |
 | `fullnameOverride` | Fully override the fullname template. | `""` |
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
-| `udpServer.port` | The port to expose for the UDP server receiving streamed JTI data. | `""` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/juniper-jti-plugin` |
 | `image.tag` | The tag of the image to use. | `0.1.0` |
@@ -59,7 +59,11 @@ The following table lists the configurable parameters of the Synse Juniper JTI P
 | `securityContext` | Security definitions for containers running in the Pod. | `{}` |
 | `service.annotations` | Additional annotations for the Service. | `{}` |
 | `service.labels` | Additional labels for the Service. | `{}` |
-| `service.port` | The Service port to expose. | `5010` |
+| `service.type` | The Service type, defining how it is exposed to the network. | `ClusterIP` |
+| `service.port` | The Service port to expose (http). | `5010` |
+| `service.clusterIP` | The cluster IP to assign when service type is ClusterIP. | `""` |
+| `service.jti.port` | The port to expose for the plugin's UDP server for receiving streamed Juniper telemetry. | `""` |
+| `service.jti.nodePort` | The node port to proxy requests from when service type is NodePort. | `-` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
 | `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `juniper_jti_monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |

--- a/juniper-jti/templates/NOTES.txt
+++ b/juniper-jti/templates/NOTES.txt
@@ -1,10 +1,10 @@
 {{ .Chart.Name }}
   chart: {{ .Chart.Version }}
   app:   {{ .Chart.AppVersion }}
-{{- if empty .Values.udpServer.port }}
+{{- if empty .Values.service.jti.port }}
 
 WARNING: Error detected with Juniper JTI configuration. The value for
-  'udpServer.port' was not found, but is required. It should take the
+  'service.jti.port' was not found, but is required. It should take the
   same port value of the server address specified in the plugin's
   'dynamicRegistration' block.
 {{- end }}

--- a/juniper-jti/templates/deployment.yaml
+++ b/juniper-jti/templates/deployment.yaml
@@ -57,8 +57,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
-            - name: udpServer
-              containerPort: {{ .Values.udpServer.port }}
+            - name: jti
+              containerPort: {{ .Values.service.jti.port }}
               protocol: UDP
             {{- if .Values.metrics.enabled }}
             - name: metrics

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -16,19 +16,27 @@ metadata:
     {{- toYaml .Values.service.annotations | trim | nindent 4 }}
   {{- end }}
 spec:
-  clusterIP: None
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  clusterIP: {{ .Values.service.clusterIP | default "None" }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       name: http
-    - port: {{ .Values.udpServer.port }}
-      targetPort: udpServer
-      name: udpServer
+      nodePort: null
+    - port: {{ .Values.service.jti.port }}
+      targetPort: jti
+      name: jti
       protocol: UDP
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.jti.nodePort))) }}
+      nodePort: {{ .Values.service.jti.nodePort }}
+      {{- end }}
     {{- if .Values.metrics.enabled }}
     - port: 2112
       targetPort: metrics
       name: metrics
+      nodePort: null
     {{- end }}
   selector:
     synse-component: plugin

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -48,6 +48,9 @@ metadata:
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.labels }}
+    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   ports:

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -32,13 +32,30 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.jti.nodePort))) }}
       nodePort: {{ .Values.service.jti.nodePort }}
       {{- end }}
-    {{- if .Values.metrics.enabled }}
-    - port: 2112
-      targetPort: metrics
-      name: metrics
-      nodePort: null
-    {{- end }}
   selector:
     synse-component: plugin
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
+
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-metrics
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 2112
+      targetPort: metrics
+      name: metrics
+  selector:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -20,6 +20,31 @@ image:
 metrics:
   enabled: false
 
+## Service configurations for the emulator plugin.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+## The port here should match the network address in the
+## plugin configuration, below.
+service:
+  type: ClusterIP
+  port: 5010
+  clusterIP: ""
+  annotations: {}
+  labels: {}
+
+  # Configurations for the plugin's UDP server, listening for incoming
+  # streamed JTI data. The value of port here should be the same configured
+  # in the plugin config's "dynamicRegistration" block.
+  # FIXME (etd): This is not an ideal way of defining this config, as it is
+  #   a duplicate config option from what is listed in the `config` block,
+  #   but there doesn't seem to be a clean, easy way of deduplicating the
+  #   config, so for the initial version of the chart, this is okay. If this
+  #   is missing in the configuration, a message will be printed out via
+  #   NOTES.txt.
+  jti:
+    port: ""
+    #nodePort: 30000
+
 ## Prometheus monitoring
 monitoring:
   serviceMonitor:
@@ -39,19 +64,6 @@ monitoring:
     # Labels applied to the ServiceMonitor.
     labels: {}
       #vapor.io/monitor: application
-
-## Define the port which the plugin's UDP server is configured to listen on
-## (via the `config` block). This is required in order to expose the port for
-## incoming streamed JTI data.
-##
-## FIXME (etd): This is not an ideal way of defining this config, as it is
-##   a duplicate config option from what is listed in the `config` block,
-##   but there doesn't seem to be a clean, easy way of deduplicating the
-##   config, so for the initial version of the chart, this is okay. If this
-##   is missing in the configuration, a message will be printed out via
-##   NOTES.txt.
-udpServer:
-  port: ""
 
 ## Deployment configuration options.
 deployment:
@@ -73,16 +85,6 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
-## Service configurations for the emulator plugin.
-## ref: http://kubernetes.io/docs/user-guide/services/
-##
-## The port here should match the network address in the
-## plugin configuration, below.
-service:
-  port: 5010
-  annotations: {}
-  labels: {}
 
 ## Readiness and liveness probe configuration options
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -20,6 +20,11 @@ image:
 metrics:
   enabled: false
 
+  ## Labels applied to the metrics service definition. This should be
+  ## set when running with Prometheus monitoring so the service monitor
+  ## can differentiate the metrics service from other defined services.
+  labels: {}
+
 ## Service configurations for the emulator plugin.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 ##


### PR DESCRIPTION
This PR:
- bumps the chart version to 0.1.1
- adds basic support for configuring NodePort service
- update values config to nest JTI udp server port under the `service` block
- renames juniper telemetry udp port from  `udpServer` to `jti`
- updates readme