### PR TITLE
[juniper-jti] bump chart to 0.1.2, app version to 0.1.1

### DIFF
--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: juniper-jti
-version: 0.1.1
-appVersion: 0.1.0
+version: 0.1.2
+appVersion: 0.1.1
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -49,7 +49,7 @@ A value of `-` indicates no default is defined.
 | `metrics.labels` | Additional labels for the metrics Service. This is used by the service monitor to target the exposed metrics port. | `{}` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/juniper-jti-plugin` |
-| `image.tag` | The tag of the image to use. | `0.1.0` |
+| `image.tag` | The tag of the image to use. | `0.1.1` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/juniper-jti-plugin
-  tag: "0.1.0"
+  tag: "0.1.1"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
https://github.com/vapor-ware/synse-juniper-jti-plugin/releases/tag/0.1.1