### PR TITLE
Chart updates for new app versions

### DIFF
--- a/prophetess/Chart.yaml
+++ b/prophetess/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prophetess
-version: 1.0.0
-appVersion: 0.2.0
+version: 1.0.1
+appVersion: 0.2.1
 description: A tool for extracting data from extractors, transforming that data and loading it into loaders.
 home: https://github.com/vapor-ware/prophetess
 icon: https://charts.vapor.io/.images/prophetess.png

--- a/prophetess/values.yaml
+++ b/prophetess/values.yaml
@@ -5,7 +5,7 @@
 pod:
   pullSecret: ""
   prophetess:
-    image: vaporio/prophetess:0.2.0
+    image: vaporio/prophetess:0.2.1
     pullPolicy: "Always"
     securityContext:
       privileged: false


### PR DESCRIPTION
This  PR contains app version updates  for the following charts:
- **prophetess**: `0.2.0` --> [`0.2.1`](https://github.com/vapor-ware/prophetess/releases/tag/0.2.1)