### PR TITLE
[juniper-jti] split service definitions, bump chart to 0.1.3

### DIFF
--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: juniper-jti
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.1
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -58,13 +58,17 @@ A value of `-` indicates no default is defined.
 | `pod.labels` | Additional labels for the Pod. | `{}` |
 | `pod.securityContext` | Pod security definitions. | `{}` |
 | `securityContext` | Security definitions for containers running in the Pod. | `{}` |
-| `service.annotations` | Additional annotations for the Service. | `{}` |
-| `service.labels` | Additional labels for the Service. | `{}` |
-| `service.type` | The Service type, defining how it is exposed to the network. | `ClusterIP` |
-| `service.port` | The Service port to expose (http). | `5010` |
-| `service.clusterIP` | The cluster IP to assign when service type is ClusterIP. | `""` |
+| `service.synse.annotations` | Additional annotations for the Service connecting to Synse. | `{}` |
+| `service.synse.labels` | Additional labels for the Service connecting to Synse. | `{}` |
+| `service.synse.type` | The Service type, defining how it is exposed to the network, for the Service connecting to Synse. | `ClusterIP` |
+| `service.synse.port` | The Service port to expose (http), for the Service connecting to Synse. | `5010` |
+| `service.synse.clusterIP` | The cluster IP to assign when service type is ClusterIP, for the Service connecting to Synse. | `""` |
+| `service.jti.annotations` | Additional annotations for the Service receiving JTI data. | `{}` |
+| `service.jti.labels` | Additional labels for the Service receiving JTI data. | `{}` |
+| `service.jti.type` | The Service type, defining how it is exposed to the network, for the Service receiving JTI data. | `ClusterIP` |
 | `service.jti.port` | The port to expose for the plugin's UDP server for receiving streamed Juniper telemetry. | `""` |
-| `service.jti.nodePort` | The node port to proxy requests from when service type is NodePort. | `-` |
+| `service.jti.clusterIP` | The cluster IP to assign when service type is ClusterIP, for the Service receiving JTI data. | `""` |
+| `service.jti.nodePort` | The node port to proxy requests from when service type is NodePort, for the Service receiving JTI data. | `-` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
 | `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `juniper_jti_monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |

--- a/juniper-jti/templates/deployment.yaml
+++ b/juniper-jti/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.synse.port }}
             - name: jti
               containerPort: {{ .Values.service.jti.port }}
               protocol: UDP

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -1,35 +1,63 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-synse
   labels:
     synse-component: plugin
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- if .Values.service.synse.labels }}
+    {{- toYaml .Values.service.synse.labels | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.service.annotations }}
+  {{- if .Values.service.synse.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+    {{- toYaml .Values.service.synse.annotations | trim | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type | default "ClusterIP" }}
-  {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
-  clusterIP: {{ .Values.service.clusterIP | default "None" }}
+  type: {{ .Values.service.synse.type | default "ClusterIP" }}
+  {{- if (or (eq .Values.service.synse.type "ClusterIP") (empty .Values.service.synse.type)) }}
+  clusterIP: {{ .Values.service.synse.clusterIP | default "" }}
   {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.synse.port }}
       targetPort: http
       name: http
-      nodePort: null
+  selector:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-jti
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.service.jti.labels }}
+    {{- toYaml .Values.service.jti.labels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.jti.annotations }}
+  annotations:
+    {{- toYaml .Values.service.jti.annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.jti.type | default "ClusterIP" }}
+  {{- if (or (eq .Values.service.jti.type "ClusterIP") (empty .Values.service.jti.type)) }}
+  clusterIP: {{ .Values.service.jti.clusterIP | default "" }}
+  {{- end }}
+  ports:
     - port: {{ .Values.service.jti.port }}
       targetPort: jti
       name: jti
       protocol: UDP
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.jti.nodePort))) }}
+      {{- if (and (eq .Values.service.jti.type "NodePort") (not (empty .Values.service.jti.nodePort))) }}
       nodePort: {{ .Values.service.jti.nodePort }}
       {{- end }}
   selector:

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -31,11 +31,12 @@ metrics:
 ## The port here should match the network address in the
 ## plugin configuration, below.
 service:
-  type: ClusterIP
-  port: 5010
-  clusterIP: ""
-  annotations: {}
-  labels: {}
+  # Configurations for the plugin's port connecting to Synse Server.
+  synse:
+    type: ClusterIP
+    port: 5010
+    annotations: {}
+    labels: {}
 
   # Configurations for the plugin's UDP server, listening for incoming
   # streamed JTI data. The value of port here should be the same configured
@@ -47,8 +48,11 @@ service:
   #   is missing in the configuration, a message will be printed out via
   #   NOTES.txt.
   jti:
+    type: ClusterIP
     port: ""
     #nodePort: 30000
+    annotations: {}
+    labels: {}
 
 ## Prometheus monitoring
 monitoring:


### PR DESCRIPTION
This PR:
-  bumps the chart version to 0.1.3
- splits the service definition to allow setting the JTI UDP port to a load  balancer
- fixed issue where no ClusterIP specified defaulted to None
- update readme