### PR TITLE
[openconfig] add support for mounting in tls key/cert/ca as secret

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openconfig
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.1.0
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 home: https://github.com/vapor-ware/synse-openconfig-plugin

--- a/openconfig/README.md
+++ b/openconfig/README.md
@@ -62,6 +62,10 @@ A value of `-` indicates no default is defined.
 | `service.labels` | Additional labels for the Service connecting to Synse. | `{}` |
 | `service.type` | The Service type, defining how it is exposed to the network, for the Service connecting to Synse. | `ClusterIP` |
 | `service.port` | The Service port to expose (http), for the Service connecting to Synse. | `5011` |
+| `tls.enabled` | Enable/disable the use of client TLS certs. | `false` |
+| `tls.key` | Private key to use for gRPC client TLS. | `""` |
+| `tls.cert` | Public cert to use for gRPC client TLS. | `""` |
+| `tls.ca` | PEM file to use a Certificate Authority for gRPC client TLS. | `""` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
 | `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `openconfig_monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |

--- a/openconfig/templates/deployment.yaml
+++ b/openconfig/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
         - name: config
           configMap:
             name: {{ template "fullname" . }}-config
+        {{- if .Values.tls.enabled }}
+        - name: tls-secrets
+          secret:
+            secretName: {{ template "fullname" . }}-tls-secrets
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -72,11 +77,17 @@ spec:
             {{- if .Values.env }}
             {{- toYaml .Values.env | trim | nindent 12}}
             {{- end }}
-          {{- if .Values.config }}
+          {{- if (or .Values.config .Values.tls.enabled) }}
           volumeMounts:
+            {{- if .Values.config }}
             - name: config
               mountPath: /etc/synse/plugin/config/config.yml
               subPath: config.yml
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: tls-secrets
+              mountPath: /keys
+            {{- end }}
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           {{- with .Values.livenessProbe }}

--- a/openconfig/templates/secrets.yaml
+++ b/openconfig/templates/secrets.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.tls.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-tls-secrets
+  labels:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- with .Values.tls.key }}
+  openconfig_key.pem: {{ . }}
+  {{- end }}
+  {{- with .Values.tls.cert }}
+  openconfig_cert.pem: {{ . }}
+  {{- end }}
+  {{- with .Values.tls.ca }}
+  openconfig_ca.pem: {{ . }}
+  {{- end }}
+{{- end }}

--- a/openconfig/values.yaml
+++ b/openconfig/values.yaml
@@ -45,6 +45,13 @@ monitoring:
     labels: {}
       #vapor.io/monitor: application
 
+# TLS certs which will be loaded as a Secret.
+tls:
+  enabled: false
+  key: ""
+  cert: ""
+  ca: ""
+
 ## Service configuration options.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 service:


### PR DESCRIPTION
This PR:
- bumps the chart version to 0.2.0
- adds config options  for specifying tls key/cert/ca, which get mounted  in as secrets


related: https://github.com/vapor-ware/helmfiles/pull/9#discussion_r447199175