### PR TITLE
[modbus] add template for service monitor

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: modbus
-version: 2.0.1
+version: 2.1.0
 appVersion: 2.0.1
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/README.md
+++ b/modbus/README.md
@@ -58,6 +58,16 @@ The following table lists the configurable parameters of the Synse Modbus Plugin
 | `service.annotations` | Additional annotations for the Service. | `{}` |
 | `service.labels` | Additional labels for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5004` |
+| `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `modbus_monitor` |
+| `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
+| `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
+| `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |
+| `monitoring.serviceMonitor.path` | The url segment to append to the discovered service endpoint. (eg: /metrics) | `"/metrics"` |
+| `monitoring.serviceMonitor.port` | The network port to attempt to connect to. Named ports are preferred, but numeric port numbers will work. | `"metrics"` |
+| `monitoring.serviceMonitor.timeout` | Timeout, in seconds, to terminate a scrape and classify as failed. | `"4s"` |
+| `monitoring.serviceMonitor.interval` | How often to scrape the metric data. | `"5s"` |
+| `monitoring.serviceMonitor.labels` | Labels to apply to the ServiceMonitor. | `{}` |
 | `livenessProbe.enabled` | Enable/disable the liveness probe check. | `true` |
 | `livenessProbe.initialDelaySeconds` | The delay before the probe starts, in seconds. | `30` |
 | `livenessProbe.timeoutSeconds` | The timeout before the probe should fail, in seconds. | `5` |

--- a/modbus/templates/service.yaml
+++ b/modbus/templates/service.yaml
@@ -16,17 +16,39 @@ metadata:
     {{- toYaml .Values.service.annotations | trim | nindent 4 }}
   {{- end }}
 spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
   clusterIP: None
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http
     name: http
-  {{- if .Values.metrics.enabled }}
-  - port: 2112
-    targetPort: metrics
-    name: metrics
-  {{- end }}
   selector:
     synse-component: plugin
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
+
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-metrics
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.labels }}
+    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 2112
+      targetPort: metrics
+      name: metrics
+  selector:
+    synse-component: plugin
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/modbus/templates/servicemonitor.yaml
+++ b/modbus/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.metrics.enabled .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.monitoring.serviceMonitor.name | default "modbus_monitor" }}
+  {{- if .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.monitoring.serviceMonitor.labels }}
+    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
+    {{- if .Values.monitoring.serviceMonitor.path }}
+    path: {{ .Values.monitoring.serviceMonitor.path }}
+    {{- end }}
+    scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
+    targetPort: {{ .Values.monitoring.serviceMonitor.port }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "modbus_monitor" }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- end }}
+{{- end }}

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -20,6 +20,31 @@ image:
 metrics:
   enabled: false
 
+  ## Labels applied to the metrics service definition. This should be
+  ## set when running with Prometheus monitoring so the service monitor
+  ## can differentiate the metrics service from other defined services.
+  labels: {}
+
+## Prometheus monitoring
+monitoring:
+  serviceMonitor:
+    enabled: false
+    name: modbus_monitor
+    port: metrics
+    path: "/metrics"
+    timeout: 4s
+    interval: 5s
+
+    # Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups.
+    namespace: ""
+    # Which namespace the prometheus tooling should interrogate to find services and pods.
+    selectorNamespace: ""
+    # Labels used to select the services/pods to monitor.
+    selectorLabels: {}
+    # Labels applied to the ServiceMonitor.
+    labels: {}
+      #vapor.io/monitor: application
+
 ## Deployment configuration options.
 deployment:
   annotations: {}


### PR DESCRIPTION
This PR:
- adds a service monitor template for prometheus scrape of application metrics