### PR TITLE
[modbus] 2.0.3 image

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: modbus
-version: 2.1.1
-appVersion: 2.0.2
+version: 2.1.2
+appVersion: 2.0.3
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin
 icon: https://charts.vapor.io/.images/synse-modbus.jpg

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/modbus-ip-plugin
-  tag: "2.0.2"
+  tag: "2.0.3"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
Update image with device id traces from the synse sdk.

Depends on https://github.com/vapor-ware/synse-modbus-ip-plugin/pull/56 and image build.