### PR TITLE
Update service monitor default names to comply with DNS RFC

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: emulator
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.0.2
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Synse Emulator Plug
 | `service.annotations` | Additional annotations for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5001` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `emulator_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `emulator-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/emulator/templates/servicemonitor.yaml
+++ b/emulator/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "emulator_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "emulator-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "emulator_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "emulator-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -29,7 +29,7 @@ metrics:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: emulator_monitor
+    name: emulator-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: juniper-jti
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.1.1
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin

--- a/juniper-jti/README.md
+++ b/juniper-jti/README.md
@@ -70,7 +70,7 @@ A value of `-` indicates no default is defined.
 | `service.jti.clusterIP` | The cluster IP to assign when service type is ClusterIP, for the Service receiving JTI data. | `""` |
 | `service.jti.nodePort` | The node port to proxy requests from when service type is NodePort, for the Service receiving JTI data. | `-` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `juniper_jti_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `juniper-jti-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/juniper-jti/templates/servicemonitor.yaml
+++ b/juniper-jti/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "juniper_jti_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "juniper-jti-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "juniper_jti_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "juniper-jti-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -58,7 +58,7 @@ service:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: juniper_jti_monitor
+    name: juniper-jti-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: modbus
-version: 2.1.7
+version: 2.1.8
 appVersion: 2.0.8
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/README.md
+++ b/modbus/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Synse Modbus Plugin
 | `service.labels` | Additional labels for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5004` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `modbus_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `modbus-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/modbus/templates/servicemonitor.yaml
+++ b/modbus/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "modbus_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "modbus-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "modbus_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "modbus-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -29,7 +29,7 @@ metrics:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: modbus_monitor
+    name: modbus-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openconfig
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.1.1
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 home: https://github.com/vapor-ware/synse-openconfig-plugin

--- a/openconfig/README.md
+++ b/openconfig/README.md
@@ -67,7 +67,7 @@ A value of `-` indicates no default is defined.
 | `tls.cert` | Public cert to use for gRPC client TLS. | `""` |
 | `tls.ca` | PEM file to use a Certificate Authority for gRPC client TLS. | `""` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `openconfig_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `openconfig-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/openconfig/templates/servicemonitor.yaml
+++ b/openconfig/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "openconfig_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "openconfig-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "openconfig_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "openconfig-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/openconfig/values.yaml
+++ b/openconfig/values.yaml
@@ -29,7 +29,7 @@ metrics:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: openconfig_monitor
+    name: openconfig-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/snmp-ups/Chart.yaml
+++ b/snmp-ups/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: snmp-ups
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.0
 description: SNMP plugin the RFC1628 UPS MIB
 home: https://github.com/vapor-ware/synse-snmp-ups-plugin

--- a/snmp-ups/README.md
+++ b/snmp-ups/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Synse SNMP UPS Plug
 | `service.labels` | Additional labels for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5003` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `snmp_ups_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `snmp-ups-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/snmp-ups/templates/servicemonitor.yaml
+++ b/snmp-ups/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "snmp_ups_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "snmp-ups-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "snmp_ups_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "snmp-ups-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/snmp-ups/values.yaml
+++ b/snmp-ups/values.yaml
@@ -28,7 +28,7 @@ metrics:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: snmp_ups_monitor
+    name: snmp-ups-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: snmp
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.0.0
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the Synse SNMP Plugin c
 | `service.labels` | Additional labels for the Service. | `{}` |
 | `service.port` | The Service port to expose. | `5003` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `snmp_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `snmp-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |

--- a/snmp/templates/servicemonitor.yaml
+++ b/snmp/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "snmp_monitor" }}
+  name: {{ .Values.monitoring.serviceMonitor.name | default "snmp-monitor" }}
   {{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "snmp_monitor" }}
+  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "snmp-monitor" }}
   namespaceSelector:
     matchNames:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -28,7 +28,7 @@ metrics:
 monitoring:
   serviceMonitor:
     enabled: false
-    name: snmp_monitor
+    name: snmp-monitor
     port: metrics
     path: "/metrics"
     timeout: 4s

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the Synse Server chart 
 | `ingress.hostname` | The Ingress hostname. | `""` |
 | `ingress.tls` | Ingress TLS configuration (YAML). | `[]` |
 | `monitoring.serviceMonitor.enabled` | Enable/Disable the ServiceMonitor. | `false` |
-| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `synse_server_monitor` |
+| `monitoring.serviceMonitor.name` | The name of the monitor job. It may contain ASCII letters and digits, as well as underscores. It must match the regex [a-zA-Z_:][a-zA-Z0-9_]. | `synse-server-monitor` |
 | `monitoring.serviceMonitor.namespace` | Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups. | `""` |
 | `monitoring.serviceMonitor.selectorNamespace` | Declares which namespace the prometheus tooling should interrogate to find the services and pods. | `"{{ .Release.Namespace }}"` |
 | `monitoring.serviceMonitor.selectorLabels` | Labels used to select the service/pods to monitor. | `{}` |


### PR DESCRIPTION
This PR:
- fixes incorrect service monitor names so  that they comply with the DNS RFC

Related to #116