### PR TITLE
[snmp] Support Galaxy UPS.

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snmp
-version: 2.1.2
-appVersion: 2.0.1
+version: 2.1.3
+appVersion: 2.0.2
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse SNMP Plugin c
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `:2112/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/snmp-plugin` |
-| `image.tag` | The tag of the image to use. | `2.0.0` |
+| `image.tag` | The tag of the image to use. | `2.0.2` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/snmp-plugin
-  tag: "2.0.1"
+  tag: "2.0.2"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
This will support the VEM-180 UPS.
In order to merge this, we need:
- This PR to land https://github.com/vapor-ware/synse-snmp-plugin/pull/57
- Cut SNMP image version 2.0.2