### PR TITLE
[prophetess] Update chart to use a secret instead of configmap

### DIFF
--- a/prophetess/Chart.yaml
+++ b/prophetess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prophetess
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.2.1
 description: A tool for extracting data from extractors, transforming that data and loading it into loaders.
 home: https://github.com/vapor-ware/prophetess

--- a/prophetess/templates/deployment.yaml
+++ b/prophetess/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: {{ template "prophetess.fullname" . }}
         release: "{{ .Release.Name }}"
@@ -39,5 +39,5 @@ spec:
               mountPath: /etc/prophetess
       volumes:
       - name: config
-        configMap:
-          name: {{ template "prophetess.fullname" . }}
+        secret:
+          secretName: {{ template "prophetess.fullname" . }}

--- a/prophetess/templates/secret.yaml
+++ b/prophetess/templates/secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     app: {{ template "prophetess.fullname" . }}
@@ -7,6 +7,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   name: {{ template "prophetess.fullname" . }}
+type: Opaque
 data:
   pipeline.yaml: |
 {{ toYaml .Values.prophetess.config | indent 4 }}


### PR DESCRIPTION
- The configmap leaked some potentially sensitive details, the config
  seems to just embed api details into the file. This moves it to a k8s
  secret which has a different security model.

  Related to https://github.com/vapor-ware/synse-charts/issues/125