### PR TITLE
[prophetess] Update secret to base64 encode the value

### DIFF
--- a/prophetess/Chart.yaml
+++ b/prophetess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prophetess
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.2.1
 description: A tool for extracting data from extractors, transforming that data and loading it into loaders.
 home: https://github.com/vapor-ware/prophetess

--- a/prophetess/templates/secret.yaml
+++ b/prophetess/templates/secret.yaml
@@ -9,5 +9,4 @@ metadata:
   name: {{ template "prophetess.fullname" . }}
 type: Opaque
 data:
-  pipeline.yaml: |
-{{ toYaml .Values.prophetess.config | indent 4 }}
+  pipeline.yaml: {{ toYaml .Values.prophetess.config | b64enc }}


### PR DESCRIPTION
This was my mistake when I did the "bare minimum" to convert the
configmap to a secret. Secret values are by default base64 encoded, and
the chart template wasn't helping perform any of that.

1.0.4 fixes 1.0.3