### PR TITLE
[openconfig] update app to v0.2.0

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openconfig
-version: 0.2.3
-appVersion: 0.1.1
+version: 0.2.4
+appVersion: 0.2.0
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 home: https://github.com/vapor-ware/synse-openconfig-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/openconfig/README.md
+++ b/openconfig/README.md
@@ -49,7 +49,7 @@ A value of `-` indicates no default is defined.
 | `metrics.labels` | Additional labels for the metrics Service. This is used by the service monitor to target the exposed metrics port. | `{}` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/openconfig-plugin` |
-| `image.tag` | The tag of the image to use. | `0.1.1` |
+| `image.tag` | The tag of the image to use. | `0.2.0` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |

--- a/openconfig/values.yaml
+++ b/openconfig/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/openconfig-plugin
-  tag: "0.1.1"
+  tag: "0.2.0"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
Updates the Chart to use v0.2.0 of the OpenConfig plugin. [[changelog]](https://github.com/vapor-ware/synse-openconfig-plugin/releases/tag/v0.2.0)