### PR TITLE
Update OpenConfig charts to helmv3 plus other bug fixes

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -1,8 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 name: openconfig
-version: 0.2.4
-appVersion: 0.2.0
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
+
+type: application
+version: 1.0.0
+appVersion: 0.2.0
 home: https://github.com/vapor-ware/synse-openconfig-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg
 sources:

--- a/openconfig/templates/NOTES.txt
+++ b/openconfig/templates/NOTES.txt
@@ -1,3 +1,26 @@
 {{ .Chart.Name }}
   chart: {{ .Chart.Version }}
   app:   {{ .Chart.AppVersion }}
+
+Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openconfig.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "openconfig.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openconfig.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "openconfig.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/openconfig/templates/_helpers.tpl
+++ b/openconfig/templates/_helpers.tpl
@@ -2,31 +2,62 @@
 {{/*
   Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "openconfig.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
   Create a default fully qualified app name.
   We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
   If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "openconfig.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
-Create chart name and version as used by the chart label.
+  Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "openconfig.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+  Common labels
+*/}}
+{{- define "openconfig.labels" -}}
+helm.sh/chart: {{ include "openconfig.chart" . }}
+{{ include "openconfig.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+  Selector labels
+*/}}
+{{- define "openconfig.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openconfig.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+  Create the name of the service account to use
+*/}}
+{{- define "openconfig.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openconfig.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/openconfig/templates/configmap.yaml
+++ b/openconfig/templates/configmap.yaml
@@ -3,13 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ include "openconfig.fullname" . }}-config
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "openconfig.labels" . | nindent 4 }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}

--- a/openconfig/templates/deployment.yaml
+++ b/openconfig/templates/deployment.yaml
@@ -1,63 +1,61 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fullname" . }}
+  name: {{ include "openconfig.fullname" . }}
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.deployment.labels }}
-    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
   {{- if .Values.deployment.annotations }}
   annotations:
     {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
-      synse-component: plugin
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
+      {{- include "openconfig.selectorLabels" . | trim | nindent 6 }}
   template:
     metadata:
-      name: {{ template "fullname" . }}
+      name: {{ include "openconfig.fullname" . }}
       labels:
-        synse-component: plugin
-        app: {{ template "name" . }}
-        chart: {{ template "chart" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.pod.labels }}
-        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
+        {{- include "openconfig.selectorLabels" . | trim | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.pod.annotations }}
-        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 3
+      serviceAccountName: {{ include "openconfig.serviceAccountName" . }}
+      {{- with .Values.pod.securityContext }}
       securityContext:
-        {{- toYaml .Values.pod.securityContext | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- if .Values.config }}
       volumes:
         - name: config
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ include "openconfig.fullname" . }}-config
         {{- if .Values.tls.enabled }}
         - name: tls-secrets
           secret:
-            secretName: {{ template "fullname" . }}-tls-secrets
+            secretName: {{ include "openconfig.fullname" . }}-tls-secrets
         {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | trim | nindent 12 }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -68,14 +66,14 @@ spec:
               containerPort: 2112
               protocol: TCP
             {{- end }}
-          {{- if .Values.args }}
-          args: {{ .Values.args }}
+          {{- with .Values.args }}
+          args: {{ . }}
           {{- end }}
           env:
             - name: PLUGIN_METRICS_ENABLED
               value: {{ .Values.metrics.enabled | quote }}
-            {{- if .Values.env }}
-            {{- toYaml .Values.env | trim | nindent 12}}
+            {{- with .Values.env }}
+            {{- toYaml . | trim | nindent 12}}
             {{- end }}
           {{- if (or .Values.config .Values.tls.enabled) }}
           volumeMounts:
@@ -113,11 +111,19 @@ spec:
                 - /etc/synse/plugin/healthy
           {{- end }}
           {{- end }}
+          {{- with .Values.resources}}
           resources:
-            {{- toYaml .Values.resources | trim | nindent 12 }}
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}

--- a/openconfig/templates/deployment.yaml
+++ b/openconfig/templates/deployment.yaml
@@ -38,11 +38,13 @@ spec:
       securityContext:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- if .Values.config }}
+      {{- if (or .Values.config .Values.tls.enabled) }}
       volumes:
+        {{- if .Values.config }}
         - name: config
           configMap:
             name: {{ include "openconfig.fullname" . }}-config
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: tls-secrets
           secret:

--- a/openconfig/templates/hpa.yaml
+++ b/openconfig/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openconfig.fullname" . }}
+  labels:
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openconfig.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/openconfig/templates/ingress.yaml
+++ b/openconfig/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "openconfig.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/openconfig/templates/secrets.yaml
+++ b/openconfig/templates/secrets.yaml
@@ -2,13 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-tls-secrets
+  name: {{ include "openconfig.fullname" . }}-tls-secrets
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
 data:
   {{- with .Values.tls.key }}
   openconfig_key.pem: {{ . | b64enc }}

--- a/openconfig/templates/service.yaml
+++ b/openconfig/templates/service.yaml
@@ -1,19 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fullname" . }}
+  name: {{ include "openconfig.fullname" . }}
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | trim | nindent 4 }}
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.service.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
@@ -23,23 +19,18 @@ spec:
       protocol: TCP
       name: http
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "openconfig.selectorLabels" . | nindent 4 }}
 
 {{- if .Values.metrics.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ include "openconfig.fullname" . }}-metrics
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.metrics.labels }}
-    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+    {{- with .Values.metrics.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   clusterIP: None
@@ -48,7 +39,5 @@ spec:
       targetPort: metrics
       name: metrics
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "openconfig.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/openconfig/templates/serviceaccount.yaml
+++ b/openconfig/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openconfig.serviceAccountName" . }}
+  labels:
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/openconfig/templates/servicemonitor.yaml
+++ b/openconfig/templates/servicemonitor.yaml
@@ -3,22 +3,19 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.monitoring.serviceMonitor.name | default "openconfig-monitor" }}
-  {{- if .Values.monitoring.serviceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  {{- with .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.monitoring.serviceMonitor.labels }}
-    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- include "openconfig.labels" . | trim | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
   - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
-    {{- if .Values.monitoring.serviceMonitor.path }}
-    path: {{ .Values.monitoring.serviceMonitor.path }}
+    {{- with .Values.monitoring.serviceMonitor.path }}
+    path: {{ . | quote }}
     {{- end }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
     targetPort: {{ .Values.monitoring.serviceMonitor.port }}
@@ -28,9 +25,8 @@ spec:
     - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
-      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- include "openconfig.selectorLabels" . | trim | nindent 6 }}
+      {{- with .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- toYaml . | trim | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/openconfig/values.yaml
+++ b/openconfig/values.yaml
@@ -13,8 +13,9 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/openconfig-plugin
-  tag: "0.2.0"
   pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 ## Enable/disable application metrics export via Prometheus.
 metrics:
@@ -24,6 +25,17 @@ metrics:
   ## set when running with Prometheus monitoring so the service monitor
   ## can differentiate the metrics service from other defined services.
   labels: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # Labels to add to the service account
+  labels: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 ## Prometheus monitoring
 monitoring:
@@ -59,6 +71,21 @@ service:
   labels: {}
   type: ClusterIP
   port: 5011
+
+## Ingress configuration options.
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## Deployment configuration options.
 deployment:
@@ -112,6 +139,13 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
This PR:
- updates the OC plugin helm chart to helmv3
- fixes a bug in how deployment volumes were rendered
- fixes a bug in service monitor selector labels template check
- fixes inconsistent formatting
- simplifies some templating using the `with` keyword
- updates labels to use the generated ones via the helpers.tpl file

The one controversial thing here is:
- removes the `synse-component: plugin` label from chart declaration

This was done because it felt incorrect to just slap that label on as a baked-in value, feels like it should be configurable to whoever is consuming it. I can add back in if thats the consensus, just trying to better differentiate chart vs config.