### PR TITLE
bugfixes: updates to mis-configured service monitor template

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: emulator
 sources:
 - https://github.com/vapor-ware/synse-emulator-plugin.git
-version: 3.1.5
+version: 3.1.6

--- a/emulator/templates/servicemonitor.yaml
+++ b/emulator/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}

--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: juniper-jti
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.1
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin

--- a/juniper-jti/templates/servicemonitor.yaml
+++ b/juniper-jti/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}

--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: modbus
-version: 2.1.8
+version: 2.1.9
 appVersion: 2.0.8
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/templates/servicemonitor.yaml
+++ b/modbus/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}

--- a/snmp-ups/Chart.yaml
+++ b/snmp-ups/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: snmp-ups
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.0
 description: SNMP plugin the RFC1628 UPS MIB
 home: https://github.com/vapor-ware/synse-snmp-ups-plugin

--- a/snmp-ups/templates/servicemonitor.yaml
+++ b/snmp-ups/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}

--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: snmp
-version: 2.1.3
+version: 2.1.4
 appVersion: 2.0.2
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin

--- a/snmp/templates/servicemonitor.yaml
+++ b/snmp/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}

--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: synse-server
-version: 3.1.4
+version: 3.1.5
 appVersion: 3.2.0
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server

--- a/synse-server/templates/servicemonitor.yaml
+++ b/synse-server/templates/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.labels }}
+      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
       {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR:
- updates what I believe is a copy-paste bug in the service monitor template for all affected charts. bumps respective chart versions.