### PR TITLE
[snmp] Pick up #61 fix.

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snmp
-version: 2.1.4
-appVersion: 2.0.2
+version: 2.1.5
+appVersion: 2.0.3
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/snmp-plugin
-  tag: "2.0.2"
+  tag: "2.0.3"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
Picks up: https://github.com/vapor-ware/synse-snmp-plugin/pull/63

Paired with:

https://github.com/vapor-ware/edge-ops/pull/262

Need an snmp 2.0.3 release to merge / deploy on the VEM-180 only.