### PR TITLE
[snmp] 2.0.4 image

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snmp
-version: 2.1.5
-appVersion: 2.0.3
+version: 2.1.6
+appVersion: 2.0.4
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 image:
   registry: "" # Add a registry if we need to use the non-default one
   repository: vaporio/snmp-plugin
-  tag: "2.0.3"
+  tag: "2.0.4"
   pullPolicy: Always
 
 ## Enable/disable application metrics export via Prometheus.


### PR DESCRIPTION
Paired with https://github.com/vapor-ware/edge-ops/pull/264
We have a 2.0.4 image https://hub.docker.com/layers/vaporio/snmp-plugin/2.0.4/images/sha256-504bb69121e132b134ca4857e9c6b8dda77f06b7b4a2602216e673aef36160c6?context=repo
