### PR TITLE
enable password loading as secret, bump app to 0.3.0

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -3,8 +3,8 @@ name: openconfig
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 
 type: application
-version: 1.0.0
-appVersion: 0.2.0
+version: 1.1.0
+appVersion: v0.3.0
 home: https://github.com/vapor-ware/synse-openconfig-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg
 sources:

--- a/openconfig/README.md
+++ b/openconfig/README.md
@@ -49,7 +49,7 @@ A value of `-` indicates no default is defined.
 | `metrics.labels` | Additional labels for the metrics Service. This is used by the service monitor to target the exposed metrics port. | `{}` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/openconfig-plugin` |
-| `image.tag` | The tag of the image to use. | `0.2.0` |
+| `image.tag` | The tag of the image to use. | `{{ .Chart.AppVersion }}` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |

--- a/openconfig/templates/deployment.yaml
+++ b/openconfig/templates/deployment.yaml
@@ -74,6 +74,13 @@ spec:
           env:
             - name: PLUGIN_METRICS_ENABLED
               value: {{ .Values.metrics.enabled | quote }}
+            {{- range $secret := .Values.secrets }}
+            - name: {{ $secret.name | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.name }}
+                  key: secret
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | trim | nindent 12}}
             {{- end }}

--- a/openconfig/templates/secrets.yaml
+++ b/openconfig/templates/secrets.yaml
@@ -16,3 +16,17 @@ data:
   openconfig_ca.pem: {{ . | b64enc }}
   {{- end }}
 {{- end }}
+
+{{- $labs := include "openconfig.labels" . }}
+{{- range $secret := .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secret.name }}
+  labels:
+    {{- $labs | trim | nindent 4 }}
+data:
+  secret: {{ $secret.value | b64enc }}
+
+{{- end }}

--- a/openconfig/values.yaml
+++ b/openconfig/values.yaml
@@ -64,6 +64,13 @@ tls:
   cert: ""
   ca: ""
 
+## Secret values, typically OpenConfig auth passwords, to generate Secrets
+## from and mount those secrets into the container via environment variable.
+## ref: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+secrets: []
+#  - name: my_secret
+#    value: foobar
+
 ## Service configuration options.
 ## ref: http://kubernetes.io/docs/user-guide/services/
 service:


### PR DESCRIPTION
This PR: 
- updates openconfig plugin to [v0.3.0](https://github.com/vapor-ware/synse-openconfig-plugin/releases/tag/v0.3.0), which adds support for loading auth passwords via env
- updates the charts to add a `secrets` list in `values.yaml` which enables you to define the passwords as secrets. these will be loaded into Opaque secrets and those secrets will be mounted into the container as environment variables, matching the name of the secret.

<details>
<summary>Example template output <b>with</b> secrets</summary>

```console
$ helm template .
---
# Source: openconfig/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: my_secret
  labels:
    helm.sh/chart: openconfig-1.1.0
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
data:
  secret: Zm9vYmFy
---
# Source: openconfig/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-openconfig
  labels:
    helm.sh/chart: openconfig-1.1.0
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 5011
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: openconfig/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-openconfig
  labels:
    helm.sh/chart: openconfig-1.1.0
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openconfig
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      name: RELEASE-NAME-openconfig
      labels:
        app.kubernetes.io/name: openconfig
        app.kubernetes.io/instance: RELEASE-NAME
      annotations:
        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
    spec:
      terminationGracePeriodSeconds: 3
      serviceAccountName: default
      containers:
        - name: openconfig
          image: "vaporio/openconfig-plugin:v0.3.0"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 5011
              protocol: TCP
          env:
            - name: PLUGIN_METRICS_ENABLED
              value: "false"
            - name: MY_SECRET
              valueFrom:
                secretKeyRef:
                  name: my_secret
                  key: secret
          livenessProbe:
            initialDelaySeconds: 15
            timeoutSeconds: 2
            periodSeconds: 5
            exec:
              command:
                - /bin/exists
                - /etc/synse/plugin/healthy
          readinessProbe:
            initialDelaySeconds: 5
            timeoutSeconds: 2
            periodSeconds: 5
            exec:
              command:
                - /bin/exists
                - /etc/synse/plugin/healthy
```
</details>


<details>
<summary>Example template output <b>without</b> secrets</summary>

```console
$ helm template .
---
# Source: openconfig/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-openconfig
  labels:
    helm.sh/chart: openconfig-1.1.0
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 5011
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: openconfig/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-openconfig
  labels:
    helm.sh/chart: openconfig-1.1.0
    app.kubernetes.io/name: openconfig
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openconfig
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      name: RELEASE-NAME-openconfig
      labels:
        app.kubernetes.io/name: openconfig
        app.kubernetes.io/instance: RELEASE-NAME
      annotations:
        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
    spec:
      terminationGracePeriodSeconds: 3
      serviceAccountName: default
      containers:
        - name: openconfig
          image: "vaporio/openconfig-plugin:v0.3.0"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 5011
              protocol: TCP
          env:
            - name: PLUGIN_METRICS_ENABLED
              value: "false"
          livenessProbe:
            initialDelaySeconds: 15
            timeoutSeconds: 2
            periodSeconds: 5
            exec:
              command:
                - /bin/exists
                - /etc/synse/plugin/healthy
          readinessProbe:
            initialDelaySeconds: 5
            timeoutSeconds: 2
            periodSeconds: 5
            exec:
              command:
                - /bin/exists
                - /etc/synse/plugin/healthy
```
</details>