### PR TITLE
[openconfig] fix bug where secret name must follow DNS-1123 spec

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -3,7 +3,7 @@ name: openconfig
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: v0.3.0
 home: https://github.com/vapor-ware/synse-openconfig-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/openconfig/templates/deployment.yaml
+++ b/openconfig/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: {{ $secret.name | upper }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $secret.name }}
+                  name: {{ $secret.name | replace "_" "-" }}
                   key: secret
             {{- end }}
             {{- with .Values.env }}

--- a/openconfig/templates/secrets.yaml
+++ b/openconfig/templates/secrets.yaml
@@ -23,7 +23,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secret.name }}
+  name: {{ $secret.name | replace "_" "-" }}
   labels:
     {{- $labs | trim | nindent 4 }}
 data:


### PR DESCRIPTION
This PR:
- fixes a bug where the secret cannot be applied because its name does not adhere to the DNS-1123 spec.

  ```
  Error: Secret "efr1_openconfig_password" is invalid: metadata.name: Invalid value: "efr1_openconfig_password": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
  ```