### PR TITLE
[openconfig] bump app to version 0.3.1

### DIFF
--- a/openconfig/Chart.yaml
+++ b/openconfig/Chart.yaml
@@ -3,8 +3,8 @@ name: openconfig
 description: Synse plugin to collect networking telemetry with OpenConfig over gRPC
 
 type: application
-version: 1.1.1
-appVersion: v0.3.0
+version: 1.1.2
+appVersion: v0.3.1
 home: https://github.com/vapor-ware/synse-openconfig-plugin
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg
 sources:


### PR DESCRIPTION
https://github.com/vapor-ware/synse-openconfig-plugin/releases/tag/v0.3.1