### PR TITLE
[emulator] update chart to latest best practices

### DIFF
--- a/emulator/.helmignore
+++ b/emulator/.helmignore
@@ -14,8 +14,10 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 3.2.2
 description: A Synse plugin providing emulated devices and reading data
 home: https://github.com/vapor-ware/synse-emulator-plugin
@@ -13,4 +13,4 @@ maintainers:
 name: emulator
 sources:
 - https://github.com/vapor-ware/synse-emulator-plugin.git
-version: 3.1.6
+version: 4.0.0

--- a/emulator/_test_values.yaml
+++ b/emulator/_test_values.yaml
@@ -1,0 +1,180 @@
+# A values.yaml file with options fully configured to exercise the full
+# extent of chart rendering.
+# The values do not need to be meaningful, but they should approximate
+# actual usage.
+
+config:
+  key: value
+
+devices:
+  key: value
+
+globalLabels:
+  global-metadata: value
+
+image:
+  registry: docker.io/v1/
+  repository: vaporio/emulator-plugin
+  pullPolicy: Always
+  tag: test
+
+imagePullSecrets:
+  - name: my-pull-secret
+
+metrics:
+  enabled: true
+  labels:
+    rendered: test-value
+
+serviceAccount:
+  create: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  name: example
+
+deployment:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  replicas: 1
+
+securityContext:
+   capabilities:
+     drop:
+     - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
+
+pod:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  securityContext:
+     fsGroup: 2000
+
+service:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  type: ClusterIP
+  port: 5001
+
+ingress:
+  enabled: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  hosts:
+    - host: chart-example.local
+      paths:
+        - /
+  tls:
+    - secretName: chart-example-tls
+      hosts:
+        - chart-example.local
+
+serviceMonitor:
+  enabled: true
+  name: emulator-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
+
+  namespace: example
+  labels:
+    rendered: test-value
+
+  selectorNamespace: other
+  selectorLabels:
+    rendered: test-value
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  minAvailable: 2
+  maxUnavailable: 1
+
+podSecurityPolicy:
+  enabled: true
+  name: psp
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  allowances:
+    privileged: false
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    fsGroup:
+      rule: RunAsAny
+    volumes:
+      - '*'
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+args: ['--debug']
+
+env:
+  - name: FOO
+    value: bar
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector:
+  disktype: ssd
+
+tolerations:
+  - key: example-key
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - store
+        topologyKey: "kubernetes.io/hostname"

--- a/emulator/templates/NOTES.txt
+++ b/emulator/templates/NOTES.txt
@@ -1,3 +1,22 @@
-{{ .Chart.Name }}
-  chart: {{ .Chart.Version }}
-  app:   {{ .Chart.AppVersion }}
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "emulator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "emulator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "emulator.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "emulator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/emulator/templates/_helpers.tpl
+++ b/emulator/templates/_helpers.tpl
@@ -2,31 +2,62 @@
 {{/*
   Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "emulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
   Create a default fully qualified app name.
   We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
   If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "emulator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
   Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "emulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+  Common labels
+*/}}
+{{- define "emulator.labels" -}}
+helm.sh/chart: {{ include "emulator.chart" . }}
+{{ include "emulator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+  Selector labels
+*/}}
+{{- define "emulator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "emulator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+  Create the name of the service account to use
+*/}}
+{{- define "emulator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "emulator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/emulator/templates/configmap.yaml
+++ b/emulator/templates/configmap.yaml
@@ -1,34 +1,30 @@
-{{- if (or .Values.config .Values.devices) }}
 {{- if .Values.config }}
 # Plugin configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ include "emulator.fullname" . }}-config
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}
+
 {{- if .Values.devices }}
 ---
-
 # Device configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-devices
+  name: {{ include "emulator.fullname" . }}-devices
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 data:
   config.yml: {{ toYaml .Values.devices | quote }}
-{{- end }}
 {{- end }}

--- a/emulator/templates/deployment.yaml
+++ b/emulator/templates/deployment.yaml
@@ -1,127 +1,140 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "emulator.fullname" . }}
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.deployment.labels }}
-    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.deployment.annotations }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deployment.annotations }}
   annotations:
-    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
-      synse-component: plugin
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
+      {{- include "emulator.selectorLabels" . | trim | nindent 6 }}
   template:
     metadata:
-      name: {{ template "fullname" . }}
-      labels:
-        synse-component: plugin
-        app: {{ template "name" . }}
-        chart: {{ template "chart" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.pod.labels }}
-        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
-        {{- end }}
+      name: {{ include "emulator.fullname" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.pod.annotations }}
-        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "emulator.selectorLabels" . | trim | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 3
+      serviceAccountName: {{ include "emulator.serviceAccountName" . }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- if (or .Values.config .Values.devices) }}
       volumes:
         {{- if .Values.config }}
         - name: config
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ include "emulator.fullname" . }}-config
         {{- end }}
         {{- if .Values.devices }}
         - name: devices
           configMap:
-            name: {{ template "fullname" . }}-devices
+            name: {{ include "emulator.fullname" . }}-devices
         {{- end }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-        - name: http
-          containerPort: {{ .Values.service.port }}
-        {{- if .Values.metrics.enabled }}
-        - name: metrics
-          containerPort: 2112
-        {{- end }}
-        {{- if .Values.args }}
-        args: {{ .Values.args }}
-        {{- end }}
-        env:
-          - name: PLUGIN_METRICS_ENABLED
-            value: {{ .Values.metrics.enabled | quote }}
-          {{- if .Values.env }}
-          {{- toYaml .Values.env | trim | nindent 10 }}
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if (or .Values.config .Values.devices) }}
-        volumeMounts:
-        {{- if .Values.config }}
-        - name: config
-          mountPath: /etc/synse/plugin/config/config.yml
-          subPath: config.yml
-        {{- end }}
-        {{- if .Values.devices }}
-        - name: devices
-          mountPath: /etc/synse/plugin/config/device
-        {{- end }}
-        {{- end }}
-        {{- if .Values.livenessProbe.enabled }}
-        {{- with .Values.livenessProbe }}
-        livenessProbe:
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          exec:
-            command:
-              - /bin/exists
-              - /etc/synse/plugin/healthy
-        {{- end }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        {{- with .Values.readinessProbe }}
-        readinessProbe:
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          exec:
-            command:
-              - /bin/exists
-              - /etc/synse/plugin/healthy
-        {{- end }}
-        {{- end }}
-        {{- if .Values.resources }}
-        resources:
-          {{- toYaml .Values.resources | trim | nindent 10 }}
-        {{- end -}}
-      {{- if .Values.nodeSelector }}
+          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 2112
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.args }}
+          args: {{ . }}
+          {{- end }}
+          env:
+            - name: PLUGIN_METRICS_ENABLED
+              value: {{ .Values.metrics.enabled | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | trim | nindent 12 }}
+            {{- end }}
+          {{- if (or .Values.config .Values.devices) }}
+          volumeMounts:
+            {{- if .Values.config }}
+            - name: config
+              mountPath: /etc/synse/plugin/config/config.yml
+              subPath: config.yml
+            {{- end }}
+            {{- if .Values.devices }}
+            - name: devices
+              mountPath: /etc/synse/plugin/config/device
+            {{- end }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+          {{- end }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+          {{- end }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | trim | nindent 8 }}
-      {{- end }}
-      {{- if .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
       {{- end }}

--- a/emulator/templates/hpa.yaml
+++ b/emulator/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "emulator.fullname" . }}
+  labels:
+    {{- include "emulator.labels" . | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "emulator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/emulator/templates/ingress.yaml
+++ b/emulator/templates/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "emulator.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare ">=1.19.0-0" $kubeTargetVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else  -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else  }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+            {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/emulator/templates/poddisruptionbudget.yaml
+++ b/emulator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "emulator.fullname" . }}
+  labels:
+    {{- include "emulator.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "emulator.selectorLabels" . | trim | nindent 6 }}
+{{- end }}

--- a/emulator/templates/podsecuritypolicy.yaml
+++ b/emulator/templates/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.podSecurityPolicy.name | default (include "emulator.fullname" .) }}
+  labels:
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.podSecurityPolicy.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.podSecurityPolicy.allowances | trim | nindent 2 }}
+{{- end }}

--- a/emulator/templates/service.yaml
+++ b/emulator/templates/service.yaml
@@ -1,54 +1,52 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | trim | nindent 4 }}
-    {{- end }}
-  {{- if .Values.service.annotations }}
+  name: {{ include "emulator.fullname" . }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  labels:
+    vapor.io/synse: plugin
+    {{- include "emulator.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
   clusterIP: None
   ports:
-  - port: {{ .Values.service.port }}
-    targetPort: http
-    name: http
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "emulator.selectorLabels" . | trim | nindent 4 }}
 
 {{- if .Values.metrics.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ include "emulator.fullname" . }}-metrics
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.metrics.labels }}
-    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- include "emulator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   clusterIP: None
   ports:
-  - port: 2112
-    targetPort: metrics
-    name: metrics
+    - name: metrics
+      port: 2112
+      targetPort: metrics
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "emulator.selectorLabels" . | trim | nindent 4 }}
 {{- end }}

--- a/emulator/templates/serviceaccount.yaml
+++ b/emulator/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "emulator.serviceAccountName" . }}
+  labels:
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/emulator/templates/servicemonitor.yaml
+++ b/emulator/templates/servicemonitor.yaml
@@ -1,36 +1,35 @@
-{{- if and .Values.metrics.enabled .Values.monitoring.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "emulator-monitor" }}
-  {{- if .Values.monitoring.serviceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  name: {{ .Values.serviceMonitor.name | default "emulator-monitor" }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.monitoring.serviceMonitor.labels }}
-    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- include "emulator.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
-    {{- if .Values.monitoring.serviceMonitor.path }}
-    path: {{ .Values.monitoring.serviceMonitor.path }}
+  - interval: {{ .Values.serviceMonitor.interval | default "60s" }}
+    {{- with .Values.serviceMonitor.path }}
+    path: {{ . }}
     {{- end }}
-    scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
-    targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "emulator-monitor" }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout | default "30s" }}
+    targetPort: {{ .Values.serviceMonitor.port }}
+  jobLabel: {{ .Values.serviceMonitor.name | default "emulator-monitor" }}
   namespaceSelector:
     matchNames:
-    - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
+    - {{ .Values.serviceMonitor.selectorNamespace | default .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
-      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- include "emulator.selectorLabels" . | trim | nindent 6 }}
+      {{- with .Values.serviceMonitor.selectorLabels }}
+      {{- toYaml . | trim | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/emulator/values.yaml
+++ b/emulator/values.yaml
@@ -2,111 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 ## Partially override the fullname template (will maintain the release name).
 nameOverride: ""
 
 ## Fully override the fullname template.
 fullnameOverride: ""
 
-## Image configuration options.
-image:
-  registry: "" # Add a registry if we need to use the non-default one
-  repository: vaporio/emulator-plugin
-  tag: "3.2.2"
-  pullPolicy: Always
-
-## Enable/disable application metrics export via Prometheus.
-metrics:
-  enabled: false
-
-  ## Labels applied to the metrics service definition. This should be
-  ## set when running with Prometheus monitoring so the service monitor
-  ## can differentiate the metrics service from other defined services.
-  labels: {}
-
-## Prometheus monitoring
-monitoring:
-  serviceMonitor:
-    enabled: false
-    name: emulator-monitor
-    port: metrics
-    path: "/metrics"
-    timeout: 4s
-    interval: 5s
-
-    # Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups.
-    namespace: ""
-    # Which namespace the prometheus tooling should interrogate to find services and pods.
-    selectorNamespace: ""
-    # Labels used to select the services/pods to monitor.
-    selectorLabels: {}
-    # Labels applied to the ServiceMonitor.
-    labels: {}
-      #vapor.io/monitor: application
-
-## Deployment configuration options.
-deployment:
-  annotations: {}
-  labels: {}
-  replicas: 1
-
-## Pod configuration options.
-pod:
-  annotations: {}
-  labels: {}
-
-## Service configurations for the emulator plugin.
-## ref: http://kubernetes.io/docs/user-guide/services/
-##
-## The port here should match the network address in the
-## plugin configuration, below.
-service:
-  annotations: {}
-  labels: {}
-  port: 5001
-
-## Readiness and liveness probe configuration options
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 30
-  timeoutSeconds: 5
-  periodSeconds: 5
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 5
-  timeoutSeconds: 2
-  periodSeconds: 5
-
-## Pass arguments to the plugin container. For additional startup
-## logging, you can pass the --debug flag. By default, no additional
-## arguments are passed to the container.
-#args: ["--debug"]
-args: []
-
-## Allow pass-through environment variable configuration.
-env: {}
-
-## Configure resource requests and limits.
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources:
-  requests: {}
-  limits: {}
-
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-nodeSelector: {}
-
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-affinity: {}
-
 ## Synse Emulator Plugin configuration.
+##
 ## The emulator plugin image comes pre-built with a default sane configuration.
 ## The block below may be uncommented if a custom configuration is desired.
 #config:
@@ -121,3 +24,195 @@ config: {}
 ## are specified here, the emulator will use the default built-in
 ## configurations.
 devices: {}
+
+## Labels applied to all manifest objects for the Chart.
+globalLabels: {}
+
+## Image configuration options.
+image:
+  registry: ""
+  repository: vaporio/emulator-plugin
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+## Pull secrets for pulling private images.
+imagePullSecrets: []
+#  - name: my-pull-secret
+
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
+  ## Labels applied to the metrics service definition. This should be
+  ## set when running with Prometheus monitoring so the service monitor
+  ## can differentiate the metrics service from other defined services.
+  labels: {}
+
+## Service account configuration options.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  create: false
+  annotations: {}
+  labels: {}
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+## Deployment configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Configuration options for container security context.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Pod-specific configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+    # fsGroup: 2000
+
+## Service configuration options.
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+##
+## The port here should match the network address in the
+## plugin configuration, above.
+service:
+  annotations: {}
+  labels: {}
+  type: ClusterIP
+  port: 5001
+
+## Ingress configuration options.
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: internal
+    # cert-manager.io/cluster-issuer: le-gdns
+  labels: {}
+  hosts: []
+  #  - host: chart-example.local
+  #    paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## Prometheus monitoring configuration.
+## ref: https://docs.openshift.com/container-platform/4.4/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html
+serviceMonitor:
+  enabled: false
+  name: emulator-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
+
+  namespace: ""
+  labels: {}
+    # vapor.io/monitor: application
+
+  selectorNamespace: ""
+  selectorLabels: {}
+
+## Configure a horizontal pod autoscaler.
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+## Configuration options for a PodDisruptionBudget.
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+podDisruptionBudget:
+  enabled: false
+  annotations: {}
+  labels: {}
+#  minAvailable: 2
+#  maxUnavailable: 1
+
+## Configuration options for pod security policies.
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  name: ""
+  annotations: {}
+  labels: {}
+  allowances: {}
+#    privileged: false
+#    seLinux:
+#      rule: RunAsAny
+#    supplementalGroups:
+#      rule: RunAsAny
+#    runAsUser:
+#      rule: RunAsAny
+#    fsGroup:
+#      rule: RunAsAny
+#    volumes:
+#      - '*'
+
+## Readiness and liveness probe configuration options.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+## Specify arguments to pass to the container. By default, no arguments are passed.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+##
+## For additional startup logging, you can pass the --debug flag.
+#args: ["--debug"]
+args: []
+
+## Allow pass-through environment variable configuration.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+env: []
+  # - name: FOO
+  #   value: bar
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Node labels for pod assignment.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
This PR:
- picks up some new changes from the starter template, namely the introduction of globalLabels, and additional kubernetes objects that are useful
- adds missing test values
- updates target synse label to only be on the required service for discovery, and updates the label name as per https://github.com/vapor-ware/synse-charts/issues/89
- bump chart major version. 


related to #144 