### PR TITLE
[juniper-jti] update chart to latest best practices

### DIFF
--- a/juniper-jti/.helmignore
+++ b/juniper-jti/.helmignore
@@ -14,6 +14,7 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project

--- a/juniper-jti/Chart.yaml
+++ b/juniper-jti/Chart.yaml
@@ -1,6 +1,7 @@
-apiVersion: v1
+apiVersion: v2
+type: application
 name: juniper-jti
-version: 0.1.5
+version: 1.0.0
 appVersion: 0.1.1
 description: Synse plugin to consume Juniper networking telemetry (JTI) over UDP
 home: https://github.com/vapor-ware/synse-juniper-jti-plugin

--- a/juniper-jti/_test_values.yaml
+++ b/juniper-jti/_test_values.yaml
@@ -1,0 +1,163 @@
+# A values.yaml file with options fully configured to exercise the full
+# extent of chart rendering.
+# The values do not need to be meaningful, but they should approximate
+# actual usage.
+
+config:
+  key: value
+
+globalLabels:
+  global-metadata: value
+
+image:
+  registry: docker.io/v1/
+  repository: vaporio/juniper-jti
+  pullPolicy: Always
+  tag: test
+
+imagePullSecrets:
+  - name: my-pull-secret
+
+metrics:
+  enabled: true
+  labels:
+    rendered: test-value
+
+serviceAccount:
+  create: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  name: example
+
+deployment:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  replicas: 1
+
+securityContext:
+   capabilities:
+     drop:
+     - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
+
+pod:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  securityContext:
+     fsGroup: 2000
+
+service:
+  synse:
+    annotations:
+      rendered: test-value
+    labels:
+      rendered: test-value
+    type: ClusterIP
+    port: 5010
+  jti:
+    annotations:
+      rendered: test-value
+    labels:
+      rendered: test-value
+    type: ClusterIP
+    port: 4444
+
+serviceMonitor:
+  enabled: true
+  name: juniper-jti-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
+
+  namespace: example
+  labels:
+    rendered: test-value
+
+  selectorNamespace: other
+  selectorLabels:
+    rendered: test-value
+
+podDisruptionBudget:
+  enabled: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  minAvailable: 2
+  maxUnavailable: 1
+
+podSecurityPolicy:
+  enabled: true
+  name: psp
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  allowances:
+    privileged: false
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    fsGroup:
+      rule: RunAsAny
+    volumes:
+      - '*'
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+args: ['--debug']
+
+env:
+  - name: FOO
+    value: bar
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector:
+  disktype: ssd
+
+tolerations:
+  - key: example-key
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - store
+        topologyKey: "kubernetes.io/hostname"

--- a/juniper-jti/templates/NOTES.txt
+++ b/juniper-jti/templates/NOTES.txt
@@ -1,6 +1,19 @@
-{{ .Chart.Name }}
-  chart: {{ .Chart.Version }}
-  app:   {{ .Chart.AppVersion }}
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.synse.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "juniper-jti.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.synse.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "juniper-jti.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "juniper-jti.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.synse.port }}
+{{- else if contains "ClusterIP" .Values.service.synse.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "juniper-jti.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
 {{- if empty .Values.service.jti.port }}
 
 WARNING: Error detected with Juniper JTI configuration. The value for

--- a/juniper-jti/templates/_helpers.tpl
+++ b/juniper-jti/templates/_helpers.tpl
@@ -2,31 +2,62 @@
 {{/*
   Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "juniper-jti.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
   Create a default fully qualified app name.
   We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
   If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "juniper-jti.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
   Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "juniper-jti.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+  Common labels
+*/}}
+{{- define "juniper-jti.labels" -}}
+helm.sh/chart: {{ include "juniper-jti.chart" . }}
+{{ include "juniper-jti.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+  Selector labels
+*/}}
+{{- define "juniper-jti.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "juniper-jti.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+  Create the name of the service account to use
+*/}}
+{{- define "juniper-jti.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "juniper-jti.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/juniper-jti/templates/configmap.yaml
+++ b/juniper-jti/templates/configmap.yaml
@@ -3,13 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ include "juniper-jti.fullname" . }}-config
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "juniper-jti.labels" . | trim | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}

--- a/juniper-jti/templates/deployment.yaml
+++ b/juniper-jti/templates/deployment.yaml
@@ -1,77 +1,82 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fullname" . }}
+  name: {{ include "juniper-jti.fullname" . }}
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.deployment.labels }}
-    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- include "juniper-jti.labels" . | trim | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.deployment.annotations }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deployment.annotations }}
   annotations:
-    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      synse-component: plugin
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
+      {{- include "juniper-jti.selectorLabels" . | trim | nindent 6 }}
   template:
     metadata:
-      name: {{ template "fullname" . }}
-      labels:
-        synse-component: plugin
-        app: {{ template "name" . }}
-        chart: {{ template "chart" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.pod.labels }}
-        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
-        {{- end }}
+      name: {{ include "juniper-jti.fullname" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.pod.annotations }}
-        {{- toYaml .Values.pod.annotations | trim | nindent 8 }}
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "juniper-jti.selectorLabels" . | trim | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 3
+      serviceAccountName: {{ include "juniper-jti.serviceAccountName" . }}
+      {{- with .Values.pod.securityContext }}
       securityContext:
-        {{- toYaml .Values.pod.securityContext | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- if .Values.config }}
       volumes:
         - name: config
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ include "juniper-jti.fullname" . }}-config
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | trim | nindent 12 }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.synse.port }}
+              protocol: TCP
             - name: jti
               containerPort: {{ .Values.service.jti.port }}
               protocol: UDP
             {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: 2112
+              protocol: TCP
             {{- end }}
-          {{- if .Values.args }}
-          args: {{ .Values.args }}
+          {{- with .Values.args }}
+          args: {{ . }}
           {{- end }}
           env:
             - name: PLUGIN_METRICS_ENABLED
               value: {{ .Values.metrics.enabled | quote }}
-            {{- if .Values.env }}
-            {{- toYaml .Values.env | trim | nindent 12}}
+            {{- with .Values.env }}
+            {{- toYaml . | trim | nindent 12 }}
             {{- end }}
           {{- if .Values.config }}
           volumeMounts:
@@ -85,6 +90,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
             periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             exec:
               command:
                 - /bin/exists
@@ -97,17 +103,26 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
             periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             exec:
               command:
                 - /bin/exists
                 - /etc/synse/plugin/healthy
             {{- end }}
             {{- end }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | trim | nindent 12 }}
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}

--- a/juniper-jti/templates/poddisruptionbudget.yaml
+++ b/juniper-jti/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "juniper-jti.fullname" . }}
+  labels:
+    {{- include "juniper-jti.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "juniper-jti.selectorLabels" . | trim | nindent 6 }}
+{{- end }}

--- a/juniper-jti/templates/podsecuritypolicy.yaml
+++ b/juniper-jti/templates/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.podSecurityPolicy.name | default (include "juniper-jti.fullname" .) }}
+  labels:
+    {{- include "juniper-jti.labels" . | trim | nindent 4 }}
+    {{- with .Values.podSecurityPolicy.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.podSecurityPolicy.allowances | trim | nindent 2 }}
+{{- end }}

--- a/juniper-jti/templates/service.yaml
+++ b/juniper-jti/templates/service.yaml
@@ -1,92 +1,87 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-synse
-  labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.service.synse.labels }}
-    {{- toYaml .Values.service.synse.labels | trim | nindent 4 }}
-    {{- end }}
-  {{- if .Values.service.synse.annotations }}
+  name: {{ include "juniper-jti.fullname" . }}-synse
+  {{- with .Values.service.synse.annotations }}
   annotations:
-    {{- toYaml .Values.service.synse.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  labels:
+    vapor.io/synse: plugin
+    {{- include "juniper-jti.labels" . | nindent 4 }}
+    {{- with .Values.service.synse.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.synse.type | default "ClusterIP" }}
   {{- if (or (eq .Values.service.synse.type "ClusterIP") (empty .Values.service.synse.type)) }}
   clusterIP: {{ .Values.service.synse.clusterIP | default "" }}
   {{- end }}
   ports:
-    - port: {{ .Values.service.synse.port }}
+    - name: http
+      port: {{ .Values.service.synse.port }}
       targetPort: http
-      name: http
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "juniper-jti.selectorLabels" . | trim | nindent 4 }}
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-jti
-  labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.service.jti.labels }}
-    {{- toYaml .Values.service.jti.labels | trim | nindent 4 }}
-    {{- end }}
-  {{- if .Values.service.jti.annotations }}
+  name: {{ include "juniper-jti.fullname" . }}-jti
+  {{- with .Values.service.jti.annotations }}
   annotations:
-    {{- toYaml .Values.service.jti.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  labels:
+    {{- include "juniper-jti.labels" . | nindent 4 }}
+    {{- with .Values.service.jti.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.jti.type | default "ClusterIP" }}
   {{- if (or (eq .Values.service.jti.type "ClusterIP") (empty .Values.service.jti.type)) }}
   clusterIP: {{ .Values.service.jti.clusterIP | default "" }}
   {{- end }}
   ports:
-    - port: {{ .Values.service.jti.port }}
+    - name: jti
+      port: {{ .Values.service.jti.port }}
       targetPort: jti
-      name: jti
       protocol: UDP
       {{- if (and (eq .Values.service.jti.type "NodePort") (not (empty .Values.service.jti.nodePort))) }}
       nodePort: {{ .Values.service.jti.nodePort }}
       {{- end }}
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "juniper-jti.selectorLabels" . | trim | nindent 4 }}
 
 {{- if .Values.metrics.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ include "juniper-jti.fullname" . }}-metrics
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.metrics.labels }}
-    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- include "juniper-jti.labels" . | nindent 4 }}
+    {{- with .Values.metrics.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   clusterIP: None
   ports:
-    - port: 2112
+    - name: metrics
+      port: 2112
       targetPort: metrics
-      name: metrics
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "juniper-jti.selectorLabels" . | trim | nindent 4 }}
 {{- end }}

--- a/juniper-jti/templates/serviceaccount.yaml
+++ b/juniper-jti/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "juniper-jti.serviceAccountName" . }}
+  labels:
+    {{- include "juniper-jti.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/juniper-jti/templates/servicemonitor.yaml
+++ b/juniper-jti/templates/servicemonitor.yaml
@@ -1,36 +1,35 @@
-{{- if and .Values.metrics.enabled .Values.monitoring.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "juniper-jti-monitor" }}
-  {{- if .Values.monitoring.serviceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  name: {{ .Values.serviceMonitor.name | default "juniper-jti-monitor" }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.monitoring.serviceMonitor.labels }}
-    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- include "juniper-jti.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
-    {{- if .Values.monitoring.serviceMonitor.path }}
-    path: {{ .Values.monitoring.serviceMonitor.path }}
+  - interval: {{ .Values.serviceMonitor.interval | default "60s" }}
+    {{- with .Values.serviceMonitor.path }}
+    path: {{ . }}
     {{- end }}
-    scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
-    targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "juniper-jti-monitor" }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout | default "30s" }}
+    targetPort: {{ .Values.serviceMonitor.port }}
+  jobLabel: {{ .Values.serviceMonitor.name | default "juniper-jti-monitor" }}
   namespaceSelector:
     matchNames:
-    - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
+    - {{ .Values.serviceMonitor.selectorNamespace | default .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
-      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- include "juniper-jti.selectorLabels" . | trim | nindent 6 }}
+      {{- with .Values.serviceMonitor.selectorLabels }}
+      {{- toYaml . | trim | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/juniper-jti/values.yaml
+++ b/juniper-jti/values.yaml
@@ -2,19 +2,38 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 ## Partially override the fullname template (will maintain the release name).
 nameOverride: ""
 
 ## Fully override the fullname template.
 fullnameOverride: ""
 
+## Synse Plugin configuration.
+##
+## The plugin requires a plugin configuration to be provided. This should be
+## specified on a per-release level. It is left empty here.
+#config:
+#  version: 3
+#  debug: true
+#  network:
+#    type: tcp
+#    address: ":5010"
+config: {}
+
+## Labels applied to all manifest objects for the Chart.
+globalLabels: {}
+
 ## Image configuration options.
 image:
-  registry: "" # Add a registry if we need to use the non-default one
+  registry: ""
   repository: vaporio/juniper-jti-plugin
-  tag: "0.1.1"
   pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+## Pull secrets for pulling private images.
+imagePullSecrets: []
+#  - name: my-pull-secret
 
 ## Enable/disable application metrics export via Prometheus.
 metrics:
@@ -25,11 +44,46 @@ metrics:
   ## can differentiate the metrics service from other defined services.
   labels: {}
 
-## Service configurations for the plugin.
-## ref: http://kubernetes.io/docs/user-guide/services/
+## Service account configuration options.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  create: false
+  annotations: {}
+  labels: {}
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+## Deployment configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Configuration options for container security context.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Pod-specific configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+    # fsGroup: 2000
+
+## Service configuration options.
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/
 ##
 ## The port here should match the network address in the
-## plugin configuration, below.
+## plugin configuration, above.
 service:
   # Configurations for the plugin's port connecting to Synse Server.
   synse:
@@ -54,68 +108,80 @@ service:
     annotations: {}
     labels: {}
 
-## Prometheus monitoring
-monitoring:
-  serviceMonitor:
-    enabled: false
-    name: juniper-jti-monitor
-    port: metrics
-    path: "/metrics"
-    timeout: 4s
-    interval: 5s
+## Prometheus monitoring configuration.
+## ref: https://docs.openshift.com/container-platform/4.4/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html
+serviceMonitor:
+  enabled: false
+  name: juniper-jti-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
 
-    # Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups.
-    namespace: ""
-    # Which namespace the prometheus tooling should interrogate to find services and pods.
-    selectorNamespace: ""
-    # Labels used to select the services/pods to monitor.
-    selectorLabels: {}
-    # Labels applied to the ServiceMonitor.
-    labels: {}
-      #vapor.io/monitor: application
+  namespace: ""
+  labels: {}
+    # vapor.io/monitor: application
 
-## Deployment configuration options.
-deployment:
+  selectorNamespace: ""
+  selectorLabels: {}
+
+## Configuration options for a PodDisruptionBudget.
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+podDisruptionBudget:
+  enabled: false
   annotations: {}
   labels: {}
-  replicas: 1
+#  minAvailable: 2
+#  maxUnavailable: 1
 
-## Pod configuration options.
-pod:
+## Configuration options for pod security policies.
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  name: ""
   annotations: {}
   labels: {}
-  securityContext: {}
-    # fsGroup: 2000
+  allowances: {}
+#    privileged: false
+#    seLinux:
+#      rule: RunAsAny
+#    supplementalGroups:
+#      rule: RunAsAny
+#    runAsUser:
+#      rule: RunAsAny
+#    fsGroup:
+#      rule: RunAsAny
+#    volumes:
+#      - '*'
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
-## Readiness and liveness probe configuration options
+## Readiness and liveness probe configuration options.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 livenessProbe:
   enabled: true
-  initialDelaySeconds: 15
-  timeoutSeconds: 2
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
   periodSeconds: 5
+  failureThreshold: 2
+
 readinessProbe:
   enabled: true
-  initialDelaySeconds: 5
-  timeoutSeconds: 2
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
   periodSeconds: 5
+  failureThreshold: 2
 
-## Pass arguments to the plugin container. For additional startup
-## logging, you can pass the --debug flag. By default, no additional
-## arguments are passed to the container.
+## Specify arguments to pass to the container. By default, no arguments are passed.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+##
+## For additional startup logging, you can pass the --debug flag.
 #args: ["--debug"]
 args: []
 
 ## Allow pass-through environment variable configuration.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 env: []
+  # - name: FOO
+  #   value: bar
 
 ## Configure resource requests and limits.
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -127,25 +193,14 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Node labels for pod assignment.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Tolerations for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Affinity for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
-
-## Synse Plugin configuration.
-## The plugin requires a plugin configuration to be provided. This should be
-## specified on a per-release level. It is left empty here.
-#config:
-#  version: 3
-#  debug: true
-#  network:
-#    type: tcp
-#    address: ":5010"
-config: {}


### PR DESCRIPTION
This PR:
- picks up some new changes from the starter template, namely the introduction of globalLabels, and additional kubernetes objects that are useful
- adds missing test values
- updates target synse label to only be on the required service for discovery, and updates the label name as per https://github.com/vapor-ware/synse-charts/issues/89
- bump chart major version. 


related to #144 