### PR TITLE
[modbus] update chart to latest best practices

### DIFF
--- a/modbus/.helmignore
+++ b/modbus/.helmignore
@@ -14,8 +14,10 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,6 +1,7 @@
-apiVersion: v1
+apiVersion: v2
+type: application
 name: modbus
-version: 2.1.9
+version: 3.0.0
 appVersion: 2.0.8
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin

--- a/modbus/_test_values.yaml
+++ b/modbus/_test_values.yaml
@@ -1,0 +1,158 @@
+# A values.yaml file with options fully configured to exercise the full
+# extent of chart rendering.
+# The values do not need to be meaningful, but they should approximate
+# actual usage.
+
+config:
+  key: value
+
+devices:
+  key: value
+
+globalLabels:
+  global-metadata: value
+
+image:
+  registry: docker.io/v1/
+  repository: vaporio/modbus-ip-plugin
+  pullPolicy: Always
+  tag: test
+
+imagePullSecrets:
+  - name: my-pull-secret
+
+metrics:
+  enabled: true
+  labels:
+    rendered: test-value
+
+serviceAccount:
+  create: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  name: example
+
+deployment:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  replicas: 1
+
+securityContext:
+   capabilities:
+     drop:
+     - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
+
+pod:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  securityContext:
+     fsGroup: 2000
+
+service:
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  type: ClusterIP
+  port: 5004
+
+serviceMonitor:
+  enabled: true
+  name: modbus-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
+
+  namespace: example
+  labels:
+    rendered: test-value
+
+  selectorNamespace: other
+  selectorLabels:
+    rendered: test-value
+
+podDisruptionBudget:
+  enabled: true
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  minAvailable: 2
+  maxUnavailable: 1
+
+podSecurityPolicy:
+  enabled: true
+  name: psp
+  annotations:
+    rendered: test-value
+  labels:
+    rendered: test-value
+  allowances:
+    privileged: false
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    fsGroup:
+      rule: RunAsAny
+    volumes:
+      - '*'
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+args: ['--debug']
+
+env:
+  - name: FOO
+    value: bar
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector:
+  disktype: ssd
+
+tolerations:
+  - key: example-key
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - store
+        topologyKey: "kubernetes.io/hostname"

--- a/modbus/templates/NOTES.txt
+++ b/modbus/templates/NOTES.txt
@@ -1,3 +1,16 @@
-{{ .Chart.Name }}
-  chart: {{ .Chart.Version }}
-  app:   {{ .Chart.AppVersion }}
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "modbus.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "modbus.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "modbus.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "modbus.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/modbus/templates/_helpers.tpl
+++ b/modbus/templates/_helpers.tpl
@@ -2,31 +2,62 @@
 {{/*
   Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "modbus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
   Create a default fully qualified app name.
   We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
   If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "modbus.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
   Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "modbus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+  Common labels
+*/}}
+{{- define "modbus.labels" -}}
+helm.sh/chart: {{ include "modbus.chart" . }}
+{{ include "modbus.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+  Selector labels
+*/}}
+{{- define "modbus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "modbus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+  Create the name of the service account to use
+*/}}
+{{- define "modbus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "modbus.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/modbus/templates/configmap.yaml
+++ b/modbus/templates/configmap.yaml
@@ -1,34 +1,30 @@
-{{- if (or .Values.config .Values.devices) }}
 {{- if .Values.config }}
 # Plugin configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-config
+  name: {{ include "modbus.fullname" . }}-config
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 data:
   config.yml: {{ toYaml .Values.config | quote }}
 {{- end }}
+
 {{- if .Values.devices }}
 ---
-
 # Device configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-devices
+  name: {{ include "modbus.fullname" . }}-devices
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 data:
   config.yml: {{ toYaml .Values.devices | quote }}
-{{- end }}
 {{- end }}

--- a/modbus/templates/deployment.yaml
+++ b/modbus/templates/deployment.yaml
@@ -1,128 +1,138 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "modbus.fullname" . }}
   labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.deployment.labels }}
-    {{- toYaml .Values.deployment.labels | trim | nindent 4 }}
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.deployment.annotations }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deployment.annotations }}
   annotations:
-    {{- toYaml .Values.deployment.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      synse-component: plugin
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
+      {{- include "modbus.selectorLabels" . | trim | nindent 6 }}
   template:
     metadata:
-      name: {{ template "fullname" . }}
-      labels:
-        synse-component: plugin
-        app: {{ template "name" . }}
-        chart: {{ template "chart" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.pod.labels }}
-        {{- toYaml .Values.pod.labels | trim | nindent 8 }}
-        {{- end }}
+      name: {{ include "modbus.fullname" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.pod.annotations }}
-        {{- toYaml .Values.pod.annotations | trim | nindent 8}}
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "modbus.selectorLabels" . | trim | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 3
+      serviceAccountName: {{ include "modbus.serviceAccountName" . }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- if (or .Values.config .Values.devices) }}
       volumes:
         {{- if .Values.config }}
         - name: config
           configMap:
-            name: {{ template "fullname" . }}-config
+            name: {{ include "modbus.fullname" . }}-config
         {{- end }}
         {{- if .Values.devices }}
         - name: devices
           configMap:
-            name: {{ template "fullname" . }}-devices
+            name: {{ include "modbus.fullname" . }}-devices
         {{- end }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: {{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-        - name: http
-          containerPort: {{ .Values.service.port }}
-        {{- if .Values.metrics.enabled }}
-        - name: metrics
-          containerPort: 2112
-        {{- end }}
-        {{- if .Values.args }}
-        args: {{ .Values.args }}
-        {{- end }}
-        env:
-          - name: PLUGIN_METRICS_ENABLED
-            value: {{ .Values.metrics.enabled | quote }}
-          {{- if .Values.env }}
-          {{- toYaml .Values.env | trim | nindent 10 }}
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if (or .Values.config .Values.devices) }}
-        volumeMounts:
-        {{- if .Values.config }}
-        - name: config
-          mountPath: /etc/synse/plugin/config/config.yml
-          subPath: config.yml
-        {{- end }}
-        {{- if .Values.devices }}
-        - name: devices
-          mountPath: /etc/synse/plugin/config/device
-        {{- end }}
-        {{- end }}
-        {{- if .Values.livenessProbe.enabled }}
-        {{- with .Values.livenessProbe }}
-        livenessProbe:
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          exec:
-            command:
-              - /bin/exists
-              - /etc/synse/plugin/healthy
-        {{- end }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        {{- with .Values.readinessProbe }}
-        readinessProbe:
-          initialDelaySeconds: {{ .initialDelaySeconds }}
-          timeoutSeconds: {{ .timeoutSeconds }}
-          periodSeconds: {{ .periodSeconds }}
-          exec:
-            command:
-              - /bin/exists
-              - /etc/synse/plugin/healthy
-        {{- end }}
-        {{- end }}
-        {{- if .Values.resources }}
-        resources:
-          {{- toYaml .Values.resources | trim | nindent 10 }}
-        {{- end -}}
-      {{- if .Values.nodeSelector }}
+          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 2112
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.args }}
+          args: {{ . }}
+          {{- end }}
+          env:
+            - name: PLUGIN_METRICS_ENABLED
+              value: {{ .Values.metrics.enabled | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | trim | nindent 12 }}
+            {{- end }}
+          {{- if (or .Values.config .Values.devices) }}
+          volumeMounts:
+            {{- if .Values.config }}
+            - name: config
+              mountPath: /etc/synse/plugin/config/config.yml
+              subPath: config.yml
+            {{- end }}
+            {{- if .Values.devices }}
+            - name: devices
+              mountPath: /etc/synse/plugin/config/device
+            {{- end }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+          {{- end }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            exec:
+              command:
+                - /bin/exists
+                - /etc/synse/plugin/healthy
+          {{- end }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | trim | nindent 8 }}
-      {{- end }}
-      {{- if .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | trim | nindent 8 }}
+        {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}

--- a/modbus/templates/poddisruptionbudget.yaml
+++ b/modbus/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "modbus.fullname" . }}
+  labels:
+    {{- include "modbus.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "modbus.selectorLabels" . | trim | nindent 6 }}
+{{- end }}

--- a/modbus/templates/podsecuritypolicy.yaml
+++ b/modbus/templates/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.podSecurityPolicy.name | default (include "modbus.fullname" .) }}
+  labels:
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.podSecurityPolicy.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.podSecurityPolicy.allowances | trim | nindent 2 }}
+{{- end }}

--- a/modbus/templates/service.yaml
+++ b/modbus/templates/service.yaml
@@ -1,54 +1,52 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | trim | nindent 4 }}
-    {{- end }}
-  {{- if .Values.service.annotations }}
+  name: {{ include "modbus.fullname" . }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | trim | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
+  labels:
+    vapor.io/synse: plugin
+    {{- include "modbus.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
   clusterIP: None
   ports:
-  - port: {{ .Values.service.port }}
-    targetPort: http
-    name: http
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "modbus.selectorLabels" . | trim | nindent 4 }}
 
 {{- if .Values.metrics.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ include "modbus.fullname" . }}-metrics
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.metrics.labels }}
-    {{- toYaml .Values.metrics.labels | trim | nindent 4 }}
+    {{- include "modbus.labels" . | nindent 4 }}
+    {{- with .Values.metrics.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   clusterIP: None
   ports:
-    - port: 2112
+    - name: metrics
+      port: 2112
       targetPort: metrics
-      name: metrics
+      protocol: TCP
   selector:
-    synse-component: plugin
-    app: {{ template "name" . }}
-    release: {{ .Release.Name }}
+    {{- include "modbus.selectorLabels" . | trim | nindent 4 }}
 {{- end }}

--- a/modbus/templates/serviceaccount.yaml
+++ b/modbus/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "modbus.serviceAccountName" . }}
+  labels:
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/modbus/templates/servicemonitor.yaml
+++ b/modbus/templates/servicemonitor.yaml
@@ -1,36 +1,35 @@
-{{- if and .Values.metrics.enabled .Values.monitoring.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.monitoring.serviceMonitor.name | default "modbus-monitor" }}
-  {{- if .Values.monitoring.serviceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+  name: {{ .Values.serviceMonitor.name | default "modbus-monitor" }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ template "chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.monitoring.serviceMonitor.labels }}
-    {{ toYaml .Values.monitoring.serviceMonitor.labels | trim | nindent 4 }}
+    {{- include "modbus.labels" . | trim | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
+    {{- with .Values.globalLabels }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.monitoring.serviceMonitor.interval | default "60s" }}
-    {{- if .Values.monitoring.serviceMonitor.path }}
-    path: {{ .Values.monitoring.serviceMonitor.path }}
+  - interval: {{ .Values.serviceMonitor.interval | default "60s" }}
+    {{- with .Values.serviceMonitor.path }}
+    path: {{ . }}
     {{- end }}
-    scrapeTimeout: {{ .Values.monitoring.serviceMonitor.timeout | default "30s" }}
-    targetPort: {{ .Values.monitoring.serviceMonitor.port }}
-  jobLabel: {{ .Values.monitoring.serviceMonitor.name | default "modbus-monitor" }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout | default "30s" }}
+    targetPort: {{ .Values.serviceMonitor.port }}
+  jobLabel: {{ .Values.serviceMonitor.name | default "modbus-monitor" }}
   namespaceSelector:
     matchNames:
-    - {{ .Values.monitoring.serviceMonitor.selectorNamespace | default .Release.Namespace }}
+    - {{ .Values.serviceMonitor.selectorNamespace | default .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
-      release: {{ .Release.Name }}
-      {{-  if .Values.monitoring.serviceMonitor.selectorLabels }}
-      {{ toYaml .Values.monitoring.serviceMonitor.selectorLabels }}
+      {{- include "modbus.selectorLabels" . | trim | nindent 6 }}
+      {{- with .Values.serviceMonitor.selectorLabels }}
+      {{- toYaml . | trim | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/modbus/values.yaml
+++ b/modbus/values.yaml
@@ -2,110 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 ## Partially override the fullname template (will maintain the release name).
 nameOverride: ""
 
 ## Fully override the fullname template.
 fullnameOverride: ""
 
-## Image configuration options.
-image:
-  registry: "" # Add a registry if we need to use the non-default one
-  repository: vaporio/modbus-ip-plugin
-  tag: "2.0.8"
-  pullPolicy: Always
-
-## Enable/disable application metrics export via Prometheus.
-metrics:
-  enabled: false
-
-  ## Labels applied to the metrics service definition. This should be
-  ## set when running with Prometheus monitoring so the service monitor
-  ## can differentiate the metrics service from other defined services.
-  labels: {}
-
-## Prometheus monitoring
-monitoring:
-  serviceMonitor:
-    enabled: false
-    name: modbus-monitor
-    port: metrics
-    path: "/metrics"
-    timeout: 4s
-    interval: 5s
-
-    # Deploy the ServiceMonitor to a namespace other than the target for the Release. Required in some setups.
-    namespace: ""
-    # Which namespace the prometheus tooling should interrogate to find services and pods.
-    selectorNamespace: ""
-    # Labels used to select the services/pods to monitor.
-    selectorLabels: {}
-    # Labels applied to the ServiceMonitor.
-    labels: {}
-      #vapor.io/monitor: application
-
-## Deployment configuration options.
-deployment:
-  annotations: {}
-  labels: {}
-  replicas: 1
-
-## Pod configuration options.
-pod:
-  annotations: {}
-  labels: {}
-
-## Service configuration options.
-## ref: http://kubernetes.io/docs/user-guide/services/
-##
-## The port defined here should match the plugin configuration, below.
-service:
-  annotations: {}
-  labels: {}
-  port: 5004
-
-## Readiness and liveness probe configuration options
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 30
-  timeoutSeconds: 5
-  periodSeconds: 5
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 5
-  timeoutSeconds: 2
-  periodSeconds: 5
-
-## Pass arguments to the plugin container. For additional startup
-## logging, you can pass the --debug flag. By default, no additional
-## arguments are passed to the container.
-#args: ["--debug"]
-args: []
-
-## Allow pass-through environment variable configuration.
-env: {}
-
-## Configure resource requests and limits.
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources:
-  requests: {}
-  limits: {}
-
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-nodeSelector: {}
-
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-affinity: {}
-
 ## Plugin configuration
+##
 ## The configuration below specifies a basic default configuration for the plugin.
 ## Deployments which require anything different than this basic configuration will
 ## need to specify their own config wholesale - single fields may not be overridden
@@ -128,3 +32,167 @@ config:
 ## Each instance should define its own device configuration. This may be different
 ## per deployment depending on what physical assets are available.
 devices: {}
+
+## Labels applied to all manifest objects for the Chart.
+globalLabels: {}
+
+## Image configuration options.
+image:
+  registry: ""
+  repository: vaporio/modbus-ip-plugin
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+## Pull secrets for pulling private images.
+imagePullSecrets: []
+#  - name: my-pull-secret
+
+## Enable/disable application metrics export via Prometheus.
+metrics:
+  enabled: false
+
+  ## Labels applied to the metrics service definition. This should be
+  ## set when running with Prometheus monitoring so the service monitor
+  ## can differentiate the metrics service from other defined services.
+  labels: {}
+
+## Service account configuration options.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  create: false
+  annotations: {}
+  labels: {}
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+## Deployment configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+deployment:
+  annotations: {}
+  labels: {}
+  replicas: 1
+
+## Configuration options for container security context.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Pod-specific configuration options.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+    # fsGroup: 2000
+
+## Service configuration options.
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  annotations: {}
+  labels: {}
+  type: ClusterIP
+  port: 5004
+
+## Prometheus monitoring configuration.
+## ref: https://docs.openshift.com/container-platform/4.4/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html
+serviceMonitor:
+  enabled: false
+  name: modbus-monitor
+  port: metrics
+  path: /metrics
+  timeout: 4s
+  interval: 5s
+
+  namespace: ""
+  labels: {}
+    # vapor.io/monitor: application
+
+  selectorNamespace: ""
+  selectorLabels: {}
+
+## Configuration options for a PodDisruptionBudget.
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+podDisruptionBudget:
+  enabled: false
+  annotations: {}
+  labels: {}
+#  minAvailable: 2
+#  maxUnavailable: 1
+
+## Configuration options for pod security policies.
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  name: ""
+  annotations: {}
+  labels: {}
+  allowances: {}
+#    privileged: false
+#    seLinux:
+#      rule: RunAsAny
+#    supplementalGroups:
+#      rule: RunAsAny
+#    runAsUser:
+#      rule: RunAsAny
+#    fsGroup:
+#      rule: RunAsAny
+#    volumes:
+#      - '*'
+
+## Readiness and liveness probe configuration options.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+  failureThreshold: 2
+
+## Specify arguments to pass to the container. By default, no arguments are passed.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+##
+## For additional startup logging, you can pass the --debug flag.
+#args: ["--debug"]
+args: []
+
+## Allow pass-through environment variable configuration.
+## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+env: []
+  # - name: FOO
+  #   value: bar
+
+## Configure resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Node labels for pod assignment.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
This PR:
- picks up some new changes from the starter template, namely the introduction of globalLabels, and additional kubernetes objects that are useful
- adds missing test values
- updates target synse label to only be on the required service for discovery, and updates the label name as per https://github.com/vapor-ware/synse-charts/issues/89
- bump chart major version. 


related to #144 