### PR TITLE
ci: bump ci ref to 1.6.1

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'vapor@1.2.0', retriever: modernSCM([
+library identifier: 'vapor@1.6.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/vapor-ware/ci-shared.git',
     credentialsId: 'vio-bot-gh',


### PR DESCRIPTION
This PR:
- updates the ref for CI to pull in latest changes