### PR TITLE
[synse-server] fix version tag for synse server (should be prefixed with v)

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: synse-server
-version: 4.0.0
-appVersion: 3.2.0
+version: 4.0.1
+appVersion: v3.2.0
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg


### PR DESCRIPTION
This PR:
- fixes a bug found by @AdamIsrael where the tag specified in Chart.yaml is invalid because synse-server uses a v-prefix on tag versions, which the declared version was missing.