### PR TITLE
Update plugin dependencies to get device_info on reads.

### DIFF
--- a/modbus/Chart.yaml
+++ b/modbus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: modbus
-version: 3.0.0
-appVersion: 2.0.8
+version: 3.1.0
+appVersion: 2.1.3
 description: Modbus over IP plugin for Synse
 home: https://github.com/vapor-ware/synse-modbus-ip-plugin
 icon: https://charts.vapor.io/.images/synse-modbus.jpg

--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: snmp
-version: 3.0.0
-appVersion: 2.0.4
+version: 3.1.0
+appVersion: 2.1.1
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg


### PR DESCRIPTION
Partial fix for https://vaporio.atlassian.net/browse/VIO-845

Depends on these PRs:
https://github.com/vapor-ware/synse-modbus-ip-plugin/pull/75
https://github.com/vapor-ware/synse-snmp-plugin/pull/66