### PR TITLE
[snmp] Remove securityContext privileged false.

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: snmp
-version: 3.1.0
+version: 3.1.1
 appVersion: 2.1.1
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin

--- a/snmp/values.yaml
+++ b/snmp/values.yaml
@@ -98,8 +98,6 @@ pod:
   annotations: {}
   labels: {}
   hostname: ""
-  securityContext:
-    privileged: false
 
 ## Service configuration options.
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
For some reason k8 complains about it.
This is the default anyway.

helmfile diff fixed:
[helmfile-diff.txt](https://github.com/vapor-ware/synse-charts/files/6627307/helmfile-diff.txt)

previous helmfile diff with error:
```
Comparing release=north-side-snmp, chart=synse/snmp
in ./helmfile.yaml: in .helmfiles[7]: in /Users/mhink/src/vapor/edge-ops/sites/pit/ke2-pit/.helmfile/cache/ssh_github_com_vapor-ware_helmfiles_git.ref=snmp-0.0.3/releases/snmp.yaml: command "/usr/local/bin/helm" exited with non-zero status:

PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: diff (4 bytes)
  2: upgrade (7 bytes)
  3: --reset-values (14 bytes)
  4: --allow-unreleased (18 bytes)
  5: north-side-snmp (15 bytes)
  6: synse/snmp (10 bytes)
  7: --version (9 bytes)
  8: 3.1.0 (5 bytes)
  9: --namespace (11 bytes)
  10: default (7 bytes)
  11: --values (8 bytes)
  12: /var/folders/gd/6lshx9j976n9d7tc52j24hp80000gn/T/helmfile481301379/default-north-side-snmp-values-6b54cd5465 (108 bytes)
  13: --values (8 bytes)
  14: /var/folders/gd/6lshx9j976n9d7tc52j24hp80000gn/T/helmfile611062534/default-north-side-snmp-values-65c8b76cfc (108 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext
  Error: plugin "diff" exited with error

COMBINED OUTPUT:
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext
  Error: plugin "diff" exited with error
exit status 1
```