### PR TITLE
[synse-server] bump application version to v3.3.0

### DIFF
--- a/synse-server/Chart.yaml
+++ b/synse-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: synse-server
-version: 4.0.1
-appVersion: v3.2.0
+version: 4.0.2
+appVersion: v3.3.0
 description: An API to monitor and control physical and virtual infrastructure
 home: https://github.com/vapor-ware/synse-server
 icon: https://charts.vapor.io/.images/synse-server-chart.jpg

--- a/synse-server/README.md
+++ b/synse-server/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Synse Server chart 
 | `metrics.enabled` | Enable/disable application metrics export (via Prometheus) at `/metrics`. | `false` |
 | `image.registry` | The image registry to use. | `""` |
 | `image.repository` | The name of the image to use. | `vaporio/synse-server` |
-| `image.tag` | The tag of the image to use. | `v3.2.0` |
+| `image.tag` | The tag of the image to use. | `{{ .Chart.AppVersion }}` |
 | `image.pullPolicy` | The image pull policy. | `Always` |
 | `deployment.labels` | Additional labels for the Deployment. | `{}` |
 | `deployment.annotations` | Additional annotations for the Deployment. | `{}` |


### PR DESCRIPTION
This PR:
- bumps the chart to use application version  [`v3.3.0`](https://github.com/vapor-ware/synse-server/releases/tag/v3.3.0)