### PR TITLE
[snmp] pick up image 2.2.0

### DIFF
--- a/snmp/Chart.yaml
+++ b/snmp/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: snmp
-version: 3.1.5
-appVersion: 2.1.5 # Same as image tag.
+version: 3.1.6
+appVersion: 2.2.0 # Same as image tag.
 description: SNMP plugin for Synse
 home: https://github.com/vapor-ware/synse-snmp-plugin
 icon: https://charts.vapor.io/.images/synse-snmp.jpg


### PR DESCRIPTION
Requires https://github.com/vapor-ware/synse-snmp-plugin/pull/72
Supports the Tripplite UPSes in the VEM-20a2.