### PR TITLE
[VIO-2709] Add loadbalancing for emulator plugin

### DIFF
--- a/emulator/Chart.yaml
+++ b/emulator/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: emulator
 sources:
 - https://github.com/vapor-ware/synse-emulator-plugin.git
-version: 4.0.3
+version: 4.0.4

--- a/emulator/templates/service.yaml
+++ b/emulator/templates/service.yaml
@@ -17,7 +17,6 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
-  clusterIP: None
   ports:
     - name: http
       port: {{ .Values.service.port }}


### PR DESCRIPTION
Add loadbalancing to the emulator plugin by removing `clusterIP: None` from the `service.yaml` template. This is one step towards opening external access to the emulator via the synse cli.